### PR TITLE
Validate error details for invalid usage record test

### DIFF
--- a/lib/metering/schemas/src/test/test.js
+++ b/lib/metering/schemas/src/test/test.js
@@ -54,7 +54,19 @@ describe('cf-abacus-metering-schemas', () => {
                 consumer: { value: '123' }, resources: [{ unit: 'calls', quantity: 12 }] }]
             };
 
-            expect(schemas.runtimeUsage.validate.bind(schemas.runtimeUsage, usage)).to.throw('[object Object],[object Object]');
+            try {
+                schemas.runtimeUsage.validate(usage);
+            }
+            catch(error) {
+                expect(error.statusCode).to.equal(400);
+
+                // Remove statusCode property from error, so that we can explicitly compare the error details
+                delete error.statusCode;
+
+                expect(error).to.deep.equal([{ field: 'data.usage.0.start', message: 'is required', value: usage.usage[0] },
+                    { field: 'data.usage.0', message: 'has additional properties', value: 'data.usage[i].tart' }
+                ]);
+            }
         });
     });
 });


### PR DESCRIPTION
Test validation using default string representation of an object does not help to find all regressions. Replace it with a detailed comparision of error.
