### PR TITLE
Refactor metering schemas to improve reusability

### DIFF
--- a/lib/metering/schemas/src/runtime-usage.js
+++ b/lib/metering/schemas/src/runtime-usage.js
@@ -1,79 +1,18 @@
 'use strict';
 
-module.exports = () => ({
-    'title': 'Runtime Usage',
-    'description': 'Usage records for a runtime',
-    'type': 'object',
-    'required': ['usage'],
-    'properties': {
-        'usage': {
-            'type': 'array',
-            'minItems': 1,
-            'items': {
-                'type': 'object',
-                'required': ['start', 'end', 'plan_id', 'organization_guid', 'space_guid', 'resources'],
-                'properties': {
-                        'start': {
-                            'type': 'integer',
-                            'format': 'utc-millisec'
-                        },
-                        'end': {
-                            'type': 'integer',
-                            'format': 'utc-millisec'
-                        },
-                        'plan_id': {
-                            'type': 'string'
-                        },
-                        'region': {
-                            'type': 'string'
-                        },
-                        'organization_guid': {
-                            'type': 'string'
-                        },
-                        'space_guid': {
-                            'type': 'string'
-                        },
-                        'consumer': {
-                            'type': 'object',
-                            'required': ['value'],
-                            'properties': {
-                                'type': {
-                                    'enum': ['cloud_foundry_application'],
-                                    'default': 'cloud_foundry_application'
-                                },
-                                'value': {
-                                    'type': 'string'
-                                }
-                            },
-                            'additionalProperties': false
-                        },
-                        'resources': {
-                            'type': 'array',
-                            'minItems': 1,
-                            'items': {
-                                'type': 'object',
-                                'required': ['unit', 'quantity'],
-                                'properties': {
-                                    'name': {
-                                        'type': 'string'
-                                    },
-                                    'unit': {
-                                        'type': 'string'
-                                    },
-                                    'quantity': {
-                                        'type': 'number'
-                                    }
-                                },
-                                'additionalProperties': false
-                            },
-                            'additionalItems': false
-                        }
-                },
-                'additionalProperties': false
-            },
-            'additionalItems': false
-        },
-        'additionalProperties': false
-    }
-});
+// Runtime usage schema
 
+const _ = require('underscore');
+
+const types = require('./types.js');
+const usage = require('./usage.js');
+
+const clone = _.clone;
+const extend = _.extend;
+
+const object = types.object;
+const arrayOf = types.arrayOf;
+
+// Export our public functions
+module.exports = () => extend(clone(object({ usage: arrayOf(usage()) }, ['usage'])),
+    { title: 'Runtime Usage', description: 'Usage records for a runtime' });

--- a/lib/metering/schemas/src/service-instance-usage.js
+++ b/lib/metering/schemas/src/service-instance-usage.js
@@ -1,82 +1,19 @@
 'use strict';
 
-module.exports = () => ({
-    'title': 'Service Instance Usage',
-    'description': 'Usage records for a service instance',
-    'type': 'object',
-    'required': ['service_id', 'usage'],
-    'properties': {
-        'service_id': {
-            'type': 'string'
-        },
-        'usage': {
-            'type': 'array',
-            'minItems': 1,
-            'items': {
-                'type': 'object',
-                'required': ['start', 'end', 'plan_id', 'organization_guid', 'space_guid', 'resources'],
-                'properties': {
-                        'start': {
-                            'type': 'integer',
-                            'format': 'utc-millisec'
-                        },
-                        'end': {
-                            'type': 'integer',
-                            'format': 'utc-millisec'
-                        },
-                        'plan_id': {
-                            'type': 'string'
-                        },
-                        'region': {
-                            'type': 'string'
-                        },
-                        'organization_guid': {
-                            'type': 'string'
-                        },
-                        'space_guid': {
-                            'type': 'string'
-                        },
-                        'consumer': {
-                            'type': 'object',
-                            'required': ['type', 'value'],
-                            'properties': {
-                                'type': {
-                                    'enum': ['cloud_foundry_application', 'external'],
-                                    'default': 'cloud_foundry_application'
-                                },
-                                'value': {
-                                    'type': 'string'
-                                }
-                            },
-                            'additionalProperties': false
-                        },
-                        'resources': {
-                            'type': 'array',
-                            'minItems': 1,
-                            'items': {
-                                'type': 'object',
-                                'required': ['unit', 'quantity'],
-                                'properties': {
-                                    'name': {
-                                        'type': 'string'
-                                    },
-                                    'unit': {
-                                        'type': 'string'
-                                    },
-                                    'quantity': {
-                                        'type': 'number'
-                                    }
-                                },
-                                'additionalProperties': false
-                            },
-                            'additionalItems': false
-                        }
-                },
-                'additionalProperties': false
-            },
-            'additionalItems': false
-        },
-        'additionalProperties': false
-    }
-});
+// Service instance usage schema
 
+const _ = require('underscore');
+
+const types = require('./types.js');
+const usage = require('./usage.js');
+
+const clone = _.clone;
+const extend = _.extend;
+
+const string = types.string;
+const object = types.object;
+const arrayOf = types.arrayOf;
+
+// Export our public functions
+module.exports = () => extend(clone(object({ service_id: string(), usage: arrayOf(usage()) }, ['service_id', 'usage'])),
+    { title: 'Service Instance Usage', description: 'Usage records for a service instance' });

--- a/lib/metering/schemas/src/service-usage.js
+++ b/lib/metering/schemas/src/service-usage.js
@@ -1,94 +1,22 @@
 'use strict';
 
-module.exports = () => ({
-    'title': 'Service Usage',
-    'description': 'Usage records for a service',
-    'required': ['service_instances'],
-    'type': 'object',
-    'properties': {
-        'service_instances': {
-            'type': 'array',
-            'minItems': 1,
-            'items': {
-                'type': 'object',
-                'required': ['service_instance_id', 'usage'],
-                'properties': {
-                        'service_instance_id': {
-                            'type': 'string'
-                        },
-                        'usage': {
-                            'type': 'array',
-                            'minItems': 1,
-                            'items': {
-                                'type': 'object',
-                                'required': ['start', 'end', 'plan_id', 'organization_guid', 'space_guid', 'resources'],
-                                'properties': {
-                                        'start': {
-                                            'type': 'integer',
-                                            'format': 'utc-millisec'
-                                        },
-                                        'end': {
-                                            'type': 'integer',
-                                            'format': 'utc-millisec'
-                                        },
-                                        'plan_id': {
-                                            'type': 'string'
-                                        },
-                                        'region': {
-                                            'type': 'string'
-                                        },
-                                        'organization_guid': {
-                                            'type': 'string'
-                                        },
-                                        'space_guid': {
-                                            'type': 'string'
-                                        },
-                                        'consumer': {
-                                            'type': 'object',
-                                            'required': ['type', 'value'],
-                                            'properties': {
-                                                'type': {
-                                                    'enum': ['cloud_foundry_application', 'external'],
-                                                    'default': 'cloud_foundry_application'
-                                                },
-                                                'value': {
-                                                    'type': 'string'
-                                                }
-                                            },
-                                            'additionalProperties': false
-                                        },
-                                        'resources': {
-                                            'type': 'array',
-                                            'minItems': 1,
-                                            'items': {
-                                                'type': 'object',
-                                                'required': ['unit', 'quantity'],
-                                                'properties': {
-                                                    'name': {
-                                                        'type': 'string'
-                                                    },
-                                                    'unit': {
-                                                        'type': 'string'
-                                                    },
-                                                    'quantity': {
-                                                        'type': 'number'
-                                                    }
-                                                },
-                                                'additionalProperties': false
-                                            },
-                                            'additionalItems': false
-                                        }
-                                },
-                                'additionalProperties': false
-                            },
-                            'additionalItems': false
-                        }
-                },
-                'additionalProperties': false
-            },
-            'additionalItems': false
-        }
-    },
-    'additionalProperties': false
-});
+// Service usage schema
 
+const _ = require('underscore');
+
+const types = require('./types.js');
+const usage = require('./usage.js');
+
+const clone = _.clone;
+const extend = _.extend;
+
+const string = types.string;
+const object = types.object;
+const arrayOf = types.arrayOf;
+
+// Service instance schema
+const serviceInstance = object({ service_instance_id: string(), usage: arrayOf(usage()) }, ['service_instance_id', 'usage']);
+
+// Export our public functions
+module.exports = () => extend(clone(object({ service_instances: arrayOf(serviceInstance) }, ['service_instances'])),
+    { title: 'Service Usage', description: 'Usage records for a service' });

--- a/lib/metering/schemas/src/test/test.js
+++ b/lib/metering/schemas/src/test/test.js
@@ -64,7 +64,7 @@ describe('cf-abacus-metering-schemas', () => {
                 delete error.statusCode;
 
                 expect(error).to.deep.equal([{ field: 'data.usage.0.start', message: 'is required', value: usage.usage[0] },
-                    { field: 'data.usage.0', message: 'has additional properties', value: 'data.usage[i].tart' }
+                    { field: 'data.usage.0', message: 'has additional properties', value: 'data.usage[j].tart' }
                 ]);
             }
         });

--- a/lib/metering/schemas/src/types.js
+++ b/lib/metering/schemas/src/types.js
@@ -1,0 +1,24 @@
+'use strict';
+
+// Primitive data types based on JSON Schema
+
+const type = (t) => ({ type: t });
+const formatedType = (t, f) => ({ type: t, format: f });
+
+// Primitive data type descriptions
+
+const string = () => type('string');
+const number = () => type('number');
+const time = () => formatedType('integer', 'utc-millisec');
+
+const enumType = (e, def) => ({ enum: e, default: def });
+const object = (properties, required) => ({ type: 'object', required: required ? required : [], properties: properties, additionalProperties: false });
+const arrayOf = (items, minItems) => ({ type: 'array', minItems: minItems ? minItems : 1, items: items, additionalItems: false });
+
+// Export primitive data types
+module.exports.string = string;
+module.exports.number = number;
+module.exports.time = time;
+module.exports.enumType = enumType;
+module.exports.object = object;
+module.exports.arrayOf = arrayOf;

--- a/lib/metering/schemas/src/usage.js
+++ b/lib/metering/schemas/src/usage.js
@@ -1,0 +1,23 @@
+'use strict';
+
+// Usage  schema
+
+const types = require('./types.js');
+
+const string = types.string;
+const number = types.number;
+const time = types.time;
+
+const enumType = types.enumType;
+const object = types.object;
+const arrayOf = types.arrayOf;
+
+// Consumer schema
+const consumer = object({ type: enumType(['cloud_foundry_application', 'external'], 'cloud_foundry_application'), value: string() }, ['value']);
+
+// Resource schema
+const resource = types.object({ name: string(), unit: string(), quantity: number() }, ['unit', 'quantity']);
+
+// Export our public functions
+module.exports = () => object({ start: time(), end: time(), plan_id: string(), region: string(), organization_guid:  string(), space_guid: string(),
+    consumer: consumer, resources: arrayOf(resource) }, ['start', 'end', 'plan_id', 'organization_guid', 'space_guid', 'resources']);


### PR DESCRIPTION
Metering usage schemas are defined with usage data structure that is duplicated at service, service instance and runtime usage schemas. Convert the usage data structure into a reusable usage schema.

Primitive JSON Schema data type descriptions are duplicated at all of the metering usage schemas. Convert them into reusable functions.
