### PR TITLE
Change schema validator to throw an error when validation fails and t…

### DIFF
--- a/lib/metering/schemas/src/index.js
+++ b/lib/metering/schemas/src/index.js
@@ -4,31 +4,20 @@
 
 const schema = require('cf-abacus-schema');
 
-// Return a function that will validate a doc with the given schema
-const validate = (s) => {
-    const v = schema.validator(s);
-    return (doc) => {
-        const e = v(doc);
-        if(e) {
-            e.statusCode = 400;
-            throw e;
-        }
-        return doc;
-    };
-};
+const validator = schema.validator;
 
 // Import our various schemas and creation validate functions for them
 const serviceDefinition = require('./service-definition.js');
-serviceDefinition.validate = validate(serviceDefinition());
+serviceDefinition.validate = validator(serviceDefinition());
 
 const serviceUsage = require('./service-usage.js');
-serviceUsage.validate = validate(serviceUsage());
+serviceUsage.validate = validator(serviceUsage());
 
 const serviceInstanceUsage = require('./service-instance-usage.js');
-serviceInstanceUsage.validate = validate(serviceInstanceUsage());
+serviceInstanceUsage.validate = validator(serviceInstanceUsage());
 
 const runtimeUsage = require('./runtime-usage.js');
-runtimeUsage.validate = validate(runtimeUsage());
+runtimeUsage.validate = validator(runtimeUsage());
 
 // Export the schemas
 module.exports.serviceDefinition = serviceDefinition;

--- a/lib/metering/schemas/src/test/test.js
+++ b/lib/metering/schemas/src/test/test.js
@@ -58,14 +58,9 @@ describe('cf-abacus-metering-schemas', () => {
                 schemas.runtimeUsage.validate(usage);
             }
             catch(error) {
-                expect(error.statusCode).to.equal(400);
-
-                // Remove statusCode property from error, so that we can explicitly compare the error details
-                delete error.statusCode;
-
-                expect(error).to.deep.equal([{ field: 'data.usage.0.start', message: 'is required', value: usage.usage[0] },
+                expect(error).to.deep.equal({ statusCode: 400, message: [{ field: 'data.usage.0.start', message: 'is required', value: usage.usage[0] },
                     { field: 'data.usage.0', message: 'has additional properties', value: 'data.usage[j].tart' }
-                ]);
+                ]});
             }
         });
     });

--- a/lib/utils/schema/src/index.js
+++ b/lib/utils/schema/src/index.js
@@ -10,26 +10,34 @@ const debug = require('cf-abacus-debug')('cf-abacus-schema');
 
 // JSON Schema validator
 const validator = (schema) => {
-    const v = jsonValidator(schema, {verbose: true, greedy: true});
-    return (data) => {
-        debug('validating %o with schema %o', data, schema);
-        v(data);
-        debug('validation result for %o is %o', data, v);
-        return v.errors;
+    const validate = jsonValidator(schema, {verbose: true, greedy: true});
+    return (doc) => {
+        debug('validating %o with schema %o', doc, schema);
+
+        const isValid = validate(doc);
+        debug('validation result for %o is %o - %o', doc, isValid, validate.errors);
+
+        if (!isValid) throw { statusCode: 400, message: validate.errors };
+
+        return doc;
     };
 };
 
 // JSON Schema validator middleware
-const validate = (schema) => {
-    const v = validator(schema);
+const middleware = (schema) => {
+    const validate = validator(schema);
     return (req, res, next) => {
-        const e = v(req.body);
-        if (e) res.status(400).send(e);
-        else next();
+        try {
+            validate(req.body);
+            next();
+        }
+        catch(error) {
+            res.status(error.statusCode).send(error.message);
+        }
     };
 };
 
 // Export our public functions
 module.exports.validator = validator;
-module.exports.validate = validate;
+module.exports.validator.middleware = middleware;
 module.exports.types = types;

--- a/lib/utils/schema/src/test/test.js
+++ b/lib/utils/schema/src/test/test.js
@@ -6,7 +6,7 @@ const types = schema.types;
 
 describe('cf-abacus-schema', () => {
     it('validate a data object that matches a schema', () => {
-        const middleware = schema.validate(types.object({ x: types.number() }));
+        const validate = schema.validator.middleware(types.object({ x: types.number() }));
 
         const req = { body: { x: 1 } };
         const res = {};
@@ -14,7 +14,7 @@ describe('cf-abacus-schema', () => {
         res.send = stub().returns(res);
         const next = spy();
 
-        middleware(req, res, next);
+        validate(req, res, next);
 
         expect(next.called).to.equal(true);
         expect(res.status.called).to.equal(false);
@@ -22,7 +22,8 @@ describe('cf-abacus-schema', () => {
     });
 
     it('validate a data object that does not match a schema', () => {
-        const middleware = schema.validate(types.object({ a: types.string(), b: types.time(), c: types.enumType(['X', 'Y'], 'Y'), d: types.arrayOf(types.number()) }, ['a', 'b', 'd']));
+        const validate = schema.validator.middleware(types.object({ a: types.string(), b: types.time(), c: types.enumType(['X', 'Y'], 'Y'), d: types.arrayOf(types.number()) },
+            ['a', 'b', 'd']));
 
         const req = { body: { b: 1.23, c: 'Z', d: [1, 'x'], y: 1 } };
         const res = {};
@@ -30,7 +31,7 @@ describe('cf-abacus-schema', () => {
         res.send = stub().returns(res);
         const next = spy();
 
-        middleware(req, res, next);
+        validate(req, res, next);
 
         expect(next.called).to.equal(false);
         expect(res.status.args[0]).to.deep.equal([400]);


### PR DESCRIPTION
…o return the source doc when validation succeeds

Schema validator returns validator errors object irrespective of validation results. Metering schema wraps the schema validator and changes its behavior to throw an error when validation fails and to return the source doc when validation succeeds. Change the schema validator behavior and remove the wrapper at metering schema.
