### PR TITLE
Convert performance test options to use the standard options format

### DIFF
--- a/test/perf/package.json
+++ b/test/perf/package.json
@@ -38,7 +38,9 @@
   "devDependencies": {
     "abacus-babel": "file:../../tools/babel",
     "abacus-eslint": "file:../../tools/eslint",
-    "abacus-publish": "file:../../tools/publish"
+    "abacus-publish": "file:../../tools/publish",
+    "underscore": "^1.8.3",
+    "commander": "2.8.1"
   },
   "engines": {
     "node": ">=0.10.0",


### PR DESCRIPTION
Performance test is using custom optional parameters, convert them to
use the standardized format.
