### PR TITLE
Update accumulated usage using batched calls and then group the calls

### DIFF
--- a/lib/aggregation/accumulator/src/index.js
+++ b/lib/aggregation/accumulator/src/index.js
@@ -11,6 +11,7 @@ const batch = require('abacus-batch');
 const retry = require('abacus-retry');
 const breaker = require('abacus-breaker');
 const yieldable = require('abacus-yieldable');
+const transform = require('abacus-transform');
 const throttle = require('abacus-throttle');
 const request = require('abacus-request');
 const urienv = require('abacus-urienv');
@@ -19,11 +20,16 @@ const lockcb = require('abacus-lock');
 const db = require('abacus-aggregation-db');
 const config = require('abacus-resource-config');
 
-const omit = _.omit;
 const map = _.map;
 const zip = _.zip;
+const flatten = _.flatten;
+const last = _.last;
 const clone = _.clone;
 const extend = _.extend;
+const omit = _.omit;
+const values = _.values;
+const sortBy = _.sortBy;
+const groupBy = _.groupBy;
 
 const brequest = batch(request);
 const post = yieldable(retry(breaker(brequest.noWaitPost)));
@@ -216,6 +222,75 @@ const storeAccumulatedUsage = function *(a, aid, alogid, ulogid) {
   return aid;
 };
 
+// Get accumulated usage, update and store it
+const updateAccumulatedUsage = function *(aid, udocs) {
+  debug('Update accumulated usage for a group of %d usage docs', udocs.length);
+  // Lock based on the given resource instance and time period
+  const unlock = yield lock(aid);
+  try {
+    // Retrieve the accumulated usage for the given resource instance and
+    // time period
+    const a = yield accumulatedUsage(aid);
+
+    // Accumulate usage, starting with the initial one
+    let newa = a;
+
+    const adocs = map(udocs, (udoc) => {
+      newa = accumulate(newa, udoc.u, udoc.u);
+      return newa;
+    });
+
+    const ludoc = last(udocs);
+
+    // Store the final new accumulated usage
+    yield storeAccumulatedUsage(newa, aid,
+      ludoc.alogid, ludoc.ulogid);
+
+    return adocs;
+  }
+  finally {
+    unlock();
+  }
+};
+
+// Update accumulated usage by batching individual calls and then
+// by grouping them using the given resource instance and time period
+const batchUpdateAccumulatedUsage = yieldable(batch((b, cb) => {
+  // Map individual accumulated usage into a batch response array and
+  // then call the callback
+  const bcb = (err, adocs) => err ?
+    cb(err) : cb(null, map(adocs, (adoc) => [null, adoc]));
+
+  transform.map(b, (args, i, b, mcb) => {
+    // Map individual call arguments into a call object
+    mcb(null, { i: i, aid: args[1],
+      udoc: { u: args[0], alogid: args[2], ulogid: args[3] } });
+  }, (err, objs) => {
+    if (err) return cb(err);
+
+    // Group the transformed call objects using the given resource
+    // instance and time period
+    const groups = values(groupBy(objs, (obj) => obj.aid));
+
+    // Call updateAccumulatedUsage for each group
+    transform.map(groups, (group, i, groups, mcb) => {
+      yieldable.functioncb(updateAccumulatedUsage)(group[0].aid,
+        map(group, (obj) => obj.udoc), (err, adocs) => {
+          // Zip grouped call objects with corresponding accumulated usage
+          return mcb(null, zip(group,
+            err ? map(group, (obj) => ({ error: err })) : adocs));
+        });
+    }, (err, objs) => {
+      if (err) return bcb(err);
+
+      // Order the zipped call objects using the original call index of
+      // the batch and then return the ordered accumulated usage
+      bcb(null, map(sortBy(flatten(objs, true), (obj) => obj[0].i),
+        (obj) => obj[1]));
+    });
+  });
+}));
+
 // Accumulate the given usage
 const accumulateUsage = function *(u) {
   // Compute the usage log id and accumulated usage id
@@ -231,22 +306,8 @@ const accumulateUsage = function *(u) {
     return dup.last_accumulated_usage_id;
   }
 
-  const unlock = yield lock(aid);
-  let newa;
-  try {
-    // Retrieve the accumulated usage for the given resource instance and
-    // time period
-    const a = yield accumulatedUsage(aid);
-
-    // Accumulate new usage
-    newa = accumulate(a, u, u);
-
-    // Store the new accumulated usage
-    yield storeAccumulatedUsage(newa, aid, alogid, ulogid);
-  }
-  finally {
-    unlock();
-  }
+  // Update accumulated usage
+  const newa = yield batchUpdateAccumulatedUsage(u, aid, alogid, ulogid);
 
   // Post the new accumulated usage to the target aggregator resource partition
   const alogdoc = extend(clone(omit(newa, 'dbrev')), {
@@ -325,4 +386,3 @@ const runCLI = () => accumulator().listen();
 // Export our public functions
 module.exports = accumulator;
 module.exports.runCLI = runCLI;
-

--- a/lib/aggregation/accumulator/src/test/test.js
+++ b/lib/aggregation/accumulator/src/test/test.js
@@ -27,13 +27,9 @@ require.cache[require.resolve('abacus-cluster')].exports =
 
 // Mock the request module
 const reqmock = extend(clone(request), {
-  noWaitPost: spy((uri, req, cb) => cb())
+  batch_noWaitPost: spy((reqs, cb) => cb())
 });
 require.cache[require.resolve('abacus-request')].exports = reqmock;
-
-// Mock the batch module
-require('abacus-batch');
-require.cache[require.resolve('abacus-batch')].exports = spy((fn) => fn);
 
 const accumulator = require('..');
 
@@ -273,13 +269,14 @@ describe('abacus-usage-accumulator', () => {
     // Check posts to the aggregator service
     const checkaggr = (done) => {
       setTimeout(() => {
-        // Expect two usage docs to have been posted to the aggregator service
-        expect(reqmock.noWaitPost.args.length).to.equal(3);
-        expect(reqmock.noWaitPost.args[0][0]).to.equal(
+        // Expect three usage docs to have been posted to the aggregator
+        // service using a single batch
+        expect(reqmock.batch_noWaitPost.args.length).to.equal(1);
+        expect(reqmock.batch_noWaitPost.args[0][0][0][0]).to.equal(
           'http://localhost:9200/v1/metering/accumulated/usage');
-        expect(reqmock.noWaitPost.args[1][0]).to.equal(
+        expect(reqmock.batch_noWaitPost.args[0][0][1][0]).to.equal(
           'http://localhost:9200/v1/metering/accumulated/usage');
-        expect(reqmock.noWaitPost.args[2][0]).to.equal(
+        expect(reqmock.batch_noWaitPost.args[0][0][2][0]).to.equal(
           'http://localhost:9200/v1/metering/accumulated/usage');
         done();
       }, 500);


### PR DESCRIPTION
Improve the performance of accumulator by batching the accumulated usage
updates function call and then by grouping usage submissions in a batch
using a key formed with resource instance and time period.

In a real world scenario, we are not expecting multiple usage submissions
for a resource instance and a time period at any given point in time.
So in this case, this would not improve the performance of the accumulator.
However, if we do get multiple usage submissions for any reason, this would
improve the performance of accumulator.
