### PR TITLE
Update aggregated usage using batched calls and then group the calls

### DIFF
--- a/lib/aggregation/aggregator/src/index.js
+++ b/lib/aggregation/aggregator/src/index.js
@@ -11,6 +11,7 @@ const batch = require('abacus-batch');
 const retry = require('abacus-retry');
 const breaker = require('abacus-breaker');
 const yieldable = require('abacus-yieldable');
+const transform = require('abacus-transform');
 const throttle = require('abacus-throttle');
 const request = require('abacus-request');
 const urienv = require('abacus-urienv');
@@ -19,11 +20,17 @@ const lockcb = require('abacus-lock');
 const db = require('abacus-aggregation-db');
 const config = require('abacus-resource-config');
 
-const extend = _.extend;
 const filter = _.filter;
 const map = _.map;
-const omit = _.omit;
+const zip = _.zip;
+const flatten = _.flatten;
+const last = _.last;
 const clone = _.clone;
+const extend = _.extend;
+const omit = _.omit;
+const values = _.values;
+const sortBy = _.sortBy;
+const groupBy = _.groupBy;
 
 const lock = yieldable(lockcb);
 
@@ -287,6 +294,74 @@ const storeAggregatedUsage = function *(a, aid, alogid, uid) {
   return aid;
 };
 
+// Get aggregated usage, update and store it
+const updateAggregatedUsage = function *(aid, udocs) {
+  debug('Update aggregated usage for a group of %d usage docs', udocs.length);
+  // Lock based on the given org and time period
+  const unlock = yield lock(aid);
+  try {
+    // Retrieve last aggregated usage for the given org and time
+    const a = yield aggregatedUsage(aid);
+
+    // Aggregate usage, starting with the initial one
+    let newa = a ? a : extend(newOrg(udocs[0].u.organization_id), {
+      start: day(udocs[0].u.end),
+      end: eod(udocs[0].end)
+    });
+
+    const adocs = map(udocs, (udoc) => {
+      newa = aggregate(newa, udoc.u);
+      return newa;
+    });
+
+    // Store the final new aggregated usage
+    const ludoc = last(udocs);
+    yield storeAggregatedUsage(newa, aid, ludoc.alogid, ludoc.uid);
+
+    return adocs;
+  }
+  finally {
+    unlock();
+  }
+};
+
+// Aggregate usage by batching individual calls and then
+// by grouping them using the given org and time period
+const batchAggregateUsage = yieldable(batch((b, cb) => {
+  // Map individual aggregated usage into a batch response array and
+  // then call the callback
+  const bcb = (err, adocs) => err ?
+    cb(err) : cb(null, map(adocs, (adoc) => [null, adoc]));
+
+  transform.map(b, (args, i, b, mcb) => {
+    // Map individual call arguments into a call object
+    mcb(null, { i: i, aid: args[1],
+      udoc: { u: args[0], alogid: args[2], uid: args[3] } });
+  }, (err, objs) => {
+    if (err) return cb(err);
+
+    // Group the transformed call objects using the given org and time period
+    const groups = values(groupBy(objs, (obj) => obj.aid));
+
+    // Call updateAggregatedUsage for each group
+    transform.map(groups, (group, i, groups, mcb) => {
+      yieldable.functioncb(updateAggregatedUsage)(group[0].aid,
+        map(group, (obj) => obj.udoc), (err, adocs) => {
+          // Zip grouped call objects with corresponding aggregated usage
+          return mcb(null, zip(group,
+            err ? map(group, (obj) => ({ error: err })) : adocs));
+        });
+    }, (err, objs) => {
+      if (err) return bcb(err);
+
+      // Order the zipped call objects using the original call index of
+      // the batch and then return the ordered aggregated usage
+      bcb(null, map(sortBy(flatten(objs, true), (obj) => obj[0].i),
+        (obj) => obj[1]));
+    });
+  });
+}));
+
 // Aggregate the given accumulated usage
 const aggregateUsage = function *(u) {
   // Compute the usage log id and aggregated usage id
@@ -295,24 +370,7 @@ const aggregateUsage = function *(u) {
     [day(u.end), seqid()].join('-'));
   const uid = u.id;
 
-  const unlock = yield lock(aid);
-  let newa;
-  try {
-    // Retrieve last aggregated usage for the given org and time
-    const a = yield aggregatedUsage(aid);
-
-    // Aggregate usage
-    newa = aggregate(a ? a : extend(newOrg(u.organization_id), {
-      start: day(u.end),
-      end: eod(u.end)
-    }), u);
-
-    // Store new aggregated usage
-    yield storeAggregatedUsage(newa, aid, alogid, uid);
-  }
-  finally {
-    unlock();
-  }
+  const newa = yield batchAggregateUsage(u, aid, alogid, uid);
 
   // Log the new aggregated usage
   const alogdoc = extend(clone(omit(newa, 'dbrev', '_rev')), {

--- a/lib/aggregation/aggregator/src/test/test.js
+++ b/lib/aggregation/aggregator/src/test/test.js
@@ -30,10 +30,6 @@ require.cache[require.resolve('abacus-resource-config')].exports =
     }]
   }), config);
 
-// Mock the batch module
-require('abacus-batch');
-require.cache[require.resolve('abacus-batch')].exports = spy((fn) => fn);
-
 const aggregator = require('..');
 
 describe('abacus-usage-aggregator', () => {


### PR DESCRIPTION
Improve the performance of aggregator by batching the aggreagted usage
updates function call and then by grouping usage submissions in a batch
using a key formed with organization and time period.

Update test to not to mock the batch module.

On a sample local perf test of 40 orgs, 40 instances and 40 usage submissions,
with a total of 64,000, Reduced the end to end processing time by 2/3rd.
