### PR TITLE
Fix usage aggregator unit test to catch regressions

### DIFF
--- a/lib/aggregation/aggregator/src/index.js
+++ b/lib/aggregation/aggregator/src/index.js
@@ -229,8 +229,8 @@ const saggr = (rid) => {
 
 // Aggregate usage and return new aggregated usage
 const aggregate = (a, u) => {
-  // Revive the org aggregated usage object behavior
-  const newa = reviveOrg(a);
+  // Deep clone and revive the org aggregated usage object behavior
+  const newa = reviveOrg(JSON.parse(JSON.stringify(a)));
 
   const saggrfn = saggr(u.resource_id);
 
@@ -320,12 +320,10 @@ const updateAggregatedUsage = function *(aid, udocs) {
     const a = yield aggregatedUsage(aid);
 
     // Aggregate usage, starting with the initial one
-    let newa = a ? a : extend(newOrg(udocs[0].u.organization_id), {
-      start: day(udocs[0].u.end),
-      end: eod(udocs[0].end)
-    });
+    let newa = a ? a : newOrg(udocs[0].u.organization_id);
 
     const adocs = map(udocs, (udoc) => {
+      newa = extend(newa, { start: day(udoc.u.end), end: eod(udoc.u.end) });
       newa = aggregate(newa, udoc.u);
       return newa;
     });
@@ -429,7 +427,7 @@ routes.get('/v1/metering/aggregated/usage/:id', throttle(function *(req) {
   debug('Retrieving aggregated usage for id %s', req.params.id);
 
   // Retrieve and return the aggregated usage doc
-  const doc = omit(yield aggrdb.get(req.params.id), ['_id', '_rev']);
+  const doc = omit(yield logdb.get(req.params.id), ['_id', '_rev']);
   return {
     body: doc
   };

--- a/lib/aggregation/aggregator/src/test/test.js
+++ b/lib/aggregation/aggregator/src/test/test.js
@@ -267,9 +267,9 @@ describe('abacus-usage-aggregator', () => {
     // Define the sequence of aggregated usage we're expecting for an org
     const aggregated = [{
       organization_id: 'org_456',
-      usage_id: '222',
-      start: 1420502400000,
-      end: 1420588799999,
+      accumulated_usage_id: '222',
+      start: 1420243200000,
+      end: 1420329599999,
       resources: [
         {
           id: '1234',
@@ -322,9 +322,9 @@ describe('abacus-usage-aggregator', () => {
         }]
     }, {
       organization_id: 'org_456',
-      usage_id: '223',
-      start: 1420502400000,
-      end: 1420588799999,
+      accumulated_usage_id: '223',
+      start: 1420243200000,
+      end: 1420329599999,
       resources: [
         {
           id: '1234',
@@ -402,10 +402,15 @@ describe('abacus-usage-aggregator', () => {
         expect(err).to.equal(undefined);
         expect(val.statusCode).to.equal(200);
 
+        // Expect the accumulated usage id is same as the usage id
+        expect(val.body.accumulated_usage_id).to.deep.equal(u.id);
+        expect(val.body.accumulated_usage_id === '222' ||
+          val.body.accumulated_usage_id === '223').to.equal(true);
+
         // Expect our test aggregated values
-        if(val.body.usage_id === '222')
+        if(val.body.accumulated_usage_id === '222')
           expect(omit(val.body, 'id')).to.deep.equal(aggregated[0]);
-        if(val.body.usage_id === '223')
+        if(val.body.accumulated_usage_id === '223')
           expect(omit(val.body, 'id')).to.deep.equal(aggregated[1]);
 
         cb();


### PR DESCRIPTION
Usage aggregator unit test skips validating expected aggregated usage when
there is a regression in getting aggregated usage. Add additional validations
to catch regressions.

Fix get aggregated usage middleware to use logdb to retrieve aggregated usage.

Fix start and end property values of expected aggregated usage to match
the end date of accumulated usage.

Fix usage_id property of expected aggregated usage by renaming it to
accumulated_usage_id.

Fix batch aggregation to use correct start and end date for each aggregations.

Fix aggregate usage to deep clone the previously aggregated value before
updating it with new aggregated values.

Fix [Finishes #101808984] at Pivotal Tracker.
