### PR TITLE
Fix document update conflict error while rating a usage submission

### DIFF
--- a/lib/aggregation/rate/src/index.js
+++ b/lib/aggregation/rate/src/index.js
@@ -177,8 +177,12 @@ const rate = function *(u, r) {
     ratedspace.cost = sumPrice(ratedspace.resources);
     return ratedspace;
   });
+
+  // Use db and cache revisions from last rated usage
   if(r)
-    extend(rated, r.dbrev ? {_rev: r.dbrev} : {_rev: r._rev});
+    extend(rated,
+      r.dbrev ? { dbrev: r.dbrev, _rev: r._rev } : { _rev: r._rev });
+
   return rated;
 };
 


### PR DESCRIPTION
Add cache revision id to new rated usage when rating a second usage
submission for a time period.

Fix [Finishes #101826640] at Pivotal Tracker.
