### PR TITLE
Fix accumulated and aggregated usage log to successfully run perf test

### DIFF
--- a/lib/aggregation/accumulator/src/index.js
+++ b/lib/aggregation/accumulator/src/index.js
@@ -199,7 +199,9 @@ const updateAccumulatedUsage = function *(aid, udocs) {
     const a = yield accumulatedUsage(aid);
 
     // Accumulate usage, starting with the initial one
-    let newa = a;
+    // Remove last_accumulated_usage_id to avoid writing this property to
+    // accumulated usage log
+    let newa = omit(a, 'last_accumulated_usage_id');
 
     const adocs = map(udocs, (udoc) => {
       newa = accumulate(newa, udoc.u, udoc.u);

--- a/lib/aggregation/aggregator/src/index.js
+++ b/lib/aggregation/aggregator/src/index.js
@@ -320,7 +320,10 @@ const updateAggregatedUsage = function *(aid, udocs) {
     const a = yield aggregatedUsage(aid);
 
     // Aggregate usage, starting with the initial one
-    let newa = a ? a : newOrg(udocs[0].u.organization_id);
+    // Remove last_aggregated_usage_id to avoid writing this property to
+    // aggregated usage log
+    let newa = a ? omit(a,
+      'last_aggregated_usage_id') : newOrg(udocs[0].u.organization_id);
 
     const adocs = map(udocs, (udoc) => {
       newa = extend(newa, { start: day(udoc.u.end), end: eod(udoc.u.end) });


### PR DESCRIPTION
Accumulated and Aggregated Usage Log have an additional last_****_usage_id
property with incorrect values for second usage submission onwards for a
given time period. Since rating reuses aggregated usage log as a source rated
usage doc, this additional property ends up at the rated usage.

Remove this additional property from the log to avoid unnecessary confusion.

Fix [Finishes #101828980] at Pivotal Tracker.
