### PR TITLE
Update rated usage using batched calls and then group the calls

### DIFF
--- a/lib/aggregation/rate/package.json
+++ b/lib/aggregation/rate/package.json
@@ -46,6 +46,7 @@
     "abacus-urienv": "file:../../utils/urienv",
     "abacus-webapp": "file:../../utils/webapp",
     "abacus-yieldable": "file:../../utils/yieldable",
+    "abacus-transform": "file:../../utils/transform",
     "underscore": "^1.8.3"
   },
   "devDependencies": {

--- a/lib/aggregation/rate/src/index.js
+++ b/lib/aggregation/rate/src/index.js
@@ -4,6 +4,7 @@
 
 const _ = require('underscore');
 const yieldable = require('abacus-yieldable');
+const transform = require('abacus-transform');
 const batch = require('abacus-batch');
 const retry = require('abacus-retry');
 const breaker = require('abacus-breaker');
@@ -19,12 +20,18 @@ const config = require('abacus-resource-config');
 const prices = require('abacus-price-config');
 const db = require('abacus-aggregation-db');
 
-const map = _.map;
 const filter = _.filter;
+const map = _.map;
+const reduce = _.reduce;
+const zip = _.zip;
+const flatten = _.flatten;
+const last = _.last;
 const clone = _.clone;
 const extend = _.extend;
 const omit = _.omit;
-const reduce = _.reduce;
+const values = _.values;
+const sortBy = _.sortBy;
+const groupBy = _.groupBy;
 
 const get = yieldable(retry(breaker(request.get)));
 
@@ -110,10 +117,7 @@ const sumPrice = (list) => {
 };
 
 // Rates a given aggregated usage
-const rate = function *(u, r) {
-  // Retrieve the pricing country from the account
-  const pricingCountry = yield accountPricingCountry(u.organization_id);
-
+const rate = (u, pc, r) => {
   // Clone only the top level properties except cost since everything else
   // will be overwritten by the new aggregated usage quantities
   const newr = omit(clone(r), 'spaces', 'resources', 'cost');
@@ -137,7 +141,7 @@ const rate = function *(u, r) {
           // Clone the metric quantity and return it along with the cost
           const ratedMetric = extend(clone(a), {
             cost: ratefn(a.unit)(getprice(
-              resource.id, plan.id, a.unit, pricingCountry), a.quantity)
+              resource.id, plan.id, a.unit, pc), a.quantity)
           });
 
           // Sum the plan costs of the metric to the total cost of the metric
@@ -215,35 +219,94 @@ const storeRatedUsage = function *(r, rid, rlogid, uid) {
   return rid;
 };
 
-// Rate the given usage
-const rateUsage = function *(u) {
-  // Compute the rated log id and the aggregated log id
-  const rid = dbclient.kturi(u.organization_id, day(u.end));
-  const rlogid = dbclient.kturi(u.organization_id, [
-    day(u.end), seqid()].join('-'));
-  const uid = u.id;
-
+// Get rated usage, update and store it
+const updateRatedUsage = function *(rid, udocs) {
+  debug('Update rated usage for a group of %d usage docs', udocs.length);
+  // Lock based on the given org and time period
   const unlock = yield lock(rid);
-  let newr;
   try {
-    // Retrieve the old rated usage document
+    // Retrieve the old rated usage for the given org and time
     const r = yield ratedUsage(rid);
 
-    // Rate the usage
-    newr = r ? omit(r, 'last_rated_usage_id') :
-      { organization_id: u.organization_id, start: u.start, end: u.end };
-    newr = yield rate(u, newr);
+    // Initialize the new rated usage
+    let newr = r ? omit(r, 'last_rated_usage_id') :
+      { organization_id: udocs[0].u.organization_id, start: udocs[0].u.start,
+        end: udocs[0].u.end };
 
-    // Store the rated usage
-    yield storeRatedUsage(newr, rid, rlogid, uid);
+    // Retrieve the pricding country from the account
+    const pricingCountry =
+      yield accountPricingCountry(udocs[0].u.organization_id);
+
+    // Rate the usage docs
+    const rdocs = map(udocs, (udoc) => {
+      newr = rate(udoc.u, pricingCountry, newr);
+      return newr;
+    });
+
+    // Store the final new rated usage
+    const ludoc = last(udocs);
+    yield storeRatedUsage(newr, rid, ludoc.rlogid, ludoc.uid);
+
+    return rdocs;
   }
   finally {
     unlock();
   }
+};
+
+// Rate usage by batching individual calls and then
+// by grouping them using the given org and time period
+const batchRateUsage = yieldable(batch((b, cb) => {
+  // Map individual rated usage into a batch response array and
+  // then call the callback
+  const bcb = (err, rdocs) => err ?
+    cb(err) : cb(null, map(rdocs, (rdoc) => [null, rdoc]));
+
+  transform.map(b, (args, i, b, mcb) => {
+    // Map individual call arguments into a call object
+    mcb(null, { i: i, rid: args[1],
+      udoc: { u: args[0], rlogid: args[2], uid: args[3] } });
+  }, (err, objs) => {
+    if (err) return cb(err);
+
+    // Group the transformed call objects using the given org and time period
+    const groups = values(groupBy(objs, (obj) => obj.rid));
+
+    // Call updateRatedUsage for each group
+    transform.map(groups, (group, i, groups, mcb) => {
+      yieldable.functioncb(updateRatedUsage)(group[0].rid,
+        map(group, (obj) => obj.udoc), (err, rdocs) => {
+          // Zip grouped call objects with corresponding rated usage
+          return mcb(null, zip(group,
+            err ? map(group, (obj) => ({ error: err })) : rdocs));
+        });
+    }, (err, objs) => {
+      if (err) return bcb(err);
+
+      // Order the zipped call objects using the original call index of
+      // the batch and then return the ordered rated usage
+      bcb(null, map(sortBy(flatten(objs, true), (obj) => obj[0].i),
+        (obj) => obj[1]));
+    });
+  });
+}));
+
+
+// Rate the given usage
+const rateUsage = function *(u) {
+  // Compute the rated usage id and the rated usage log id
+  const rid = dbclient.kturi(u.organization_id, day(u.end));
+  const rlogid = dbclient.kturi(u.organization_id, [
+    day(u.end), seqid()].join('-'));
+
+  // Rate the usage
+  const newr = yield batchRateUsage(u, rid, rlogid, u.id);
+
   // Log the rated usage
   const rlogdoc = extend(clone(newr), {
     id: rlogid, aggregated_usage_id: u.id });
   yield logRatedUsage(rlogdoc, rlogid);
+
   return rlogid;
 };
 


### PR DESCRIPTION
Improve the performance of rating by batching the rated usage update function
calls and then by grouping usage submissions in a batch using a key formed
with organization and time period.

On a sample local perf test of 40 orgs, 40 instances and 40 usage submissions,
with a total of 64,000, Reduced the end to end processing time by more than
2/3rd.

Related to [#101021756] at Pivotal Tracker.
