### PR TITLE
Fix individual response headers of a batch request

### DIFF
--- a/lib/utils/request/src/index.js
+++ b/lib/utils/request/src/index.js
@@ -20,6 +20,7 @@ const sortBy = _.sortBy;
 const memoize = _.memoize;
 const filter = _.filter;
 const find = _.find;
+const omit = _.omit;
 
 /* jshint undef: false */
 /* jshint unused: false */
@@ -261,12 +262,12 @@ const batchOp = (m, opt) => {
         // Send the POST request to the target's host /batch path
         post(url.resolve(group[0].target.uri, '/batch'), {
           body: greq
-        }, (err, res) => {
+        }, (err, bres) => {
           if(err) return gcb(err);
 
           // Return the list of results from the response body
-          if(res)
-            gcb(undefined, map(res.body, (r, i) => {
+          if(bres)
+            gcb(undefined, map(bres.body, (r, i) => {
               if(r.statusCode >= 500 && r.statusCode <= 599)
                 return {
                   i: group[i].i,
@@ -276,7 +277,10 @@ const batchOp = (m, opt) => {
                 i: group[i].i,
                 res: [undefined, {
                   statusCode: r.statusCode || 200,
-                  headers: r.headers || [],
+                  headers: extend(r.headers || omit(bres.headers,
+                    [ 'content-type', 'content-length' ]) || {},
+                    r.header && r.header.Location ?
+                    { location: r.header.Location } : {}),
                   body: r.body
                 }]
               };


### PR DESCRIPTION
Using /batch endpoint through a batch request would return empty headers.

HTTP responses from middlewares with header.Location are converted to an array
of response objects with header.Location and the array is sent back to a client
as a response body of the batch request.

At the client side, this array of response objects needs to be translated back
to individual responses with correct location header for each response.

Fixes [Finishes #102122388] at Pivotal Tracker.
