### PR TITLE
Add integration test command

### DIFF
--- a/etc/src/foreach.js
+++ b/etc/src/foreach.js
@@ -17,6 +17,7 @@ var filter = _.filter;
 var initial = _.initial;
 var last = _.last;
 var pairs = _.pairs;
+var findIndex = _.findIndex;
 
 /* eslint no-process-exit: 1 */
 
@@ -102,6 +103,14 @@ var runCLI = function() {
       commander.args = args;
     })
     .parse(process.argv);
+
+  // Running an npm command with program options requires '--'
+  // before the program options
+  var oidx = findIndex(commander.args, function(arg) {
+    return /^-/.test(arg) && !/^--/.test(arg);
+  });
+  if (commander.cmd === 'npm' && oidx >= 0)
+    commander.args.splice(oidx, 0, '--');
 
   // Use the given regular expression to filter modules
   var rx = new RegExp(commander.regexp);

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "lint": "foreach abacus :path npm run lint",
     "hint": "foreach abacus :path jshint src",
     "test": "foreach abacus node_modules/:name npm test && coverage",
+    "itest": "foreach itest node_modules/:name npm run itest --",
     "coveralls": "cat .coverage/lcov.info | coveralls",
     "dupcode": "jsinspect",
     "doc": "cat README.md | mddoc >README.html",


### PR DESCRIPTION
Run all integration tests using npm run itest.

When passing program options to an npm command, npm requires -- before the
options. Foreach node script uses commander to parse process arguments.
When parsing the process arguments, Commander uses -- to identify literal
program options, removes -- from the list and retains all program options.
Add -- back to the list when using the foreach node script to run an npm
command with program options.
