### PR TITLE
Fix batch request to handle 404 responses from a server

### DIFF
--- a/lib/utils/request/src/index.js
+++ b/lib/utils/request/src/index.js
@@ -249,7 +249,12 @@ const batchOp = (m, opt) => {
             if(err) return gcb(err);
 
             // Return the list of results from the response body
-            if(bres)
+            if(bres) {
+              // Handle 404 response from /batch
+              if (bres.statusCode === 404)
+                return gcb(undefined, map(group, (g) => ({ i: g.i,
+                  res: [undefined, bres] })));
+
               gcb(undefined, map(bres.body, (r, i) => {
                 if(r.statusCode >= 500 && r.statusCode <= 599)
                   return { i: group[i].i, res: [httpexc(r), undefined] };
@@ -263,9 +268,11 @@ const batchOp = (m, opt) => {
                   body: r.body
                 }] };
               }));
+            }
             else
-              gcb(undefined, map(group, (g) => ({ i: g.i,
-                res: [undefined, undefined] })));
+              gcb(undefined, map(group, (g) => {
+                return { i: g.i, res: [undefined, undefined] };
+              }));
           });
       }, (err, gres) => {
         if(err) cb(err);

--- a/lib/utils/request/src/test/test.js
+++ b/lib/utils/request/src/test/test.js
@@ -146,6 +146,13 @@ describe('abacus-request', () => {
                 statusCode: 200,
                 body: gets++ === 0 ? 'okay' : 'notok'
               };
+            if(breq.uri === '/201/request' && breq.method ===
+              'POST')
+              // Return 201 response with location
+              return {
+                statusCode: 201,
+                header: { Location: '201/request/1' }
+              };
             else if(breq.uri === '/500/request' && breq.method ===
               'POST')
               // Don't return a body here to test request's behavior
@@ -184,7 +191,7 @@ describe('abacus-request', () => {
 
       let cbs = 0;
       const done1 = () => {
-        if(++cbs === 2) done();
+        if(++cbs === 5) done();
       };
 
       // Use a batch version of the request module
@@ -215,26 +222,70 @@ describe('abacus-request', () => {
         });
       });
 
-    /*
-    // Send an HTTP request, expecting a 500 status code
-    // Here test the option to pass the URI as a field of the options object
-    brequest.post({ uri: 'http://localhost::p/:v/:r',
-      p: server.address().port, v: '500', r: 'request' }, (err, val) => {
-        expect(err.message).to.equal('HTTP response status code 500');
-        expect(val).to.equal(undefined);
-        done1();
-    });
+      // Send an HTTP request, expecting a 201 response with location
+      brequest.post({ uri: 'http://localhost::p/:v/:r',
+        p: server.address().port, v: '201', r: 'request' }, (err, val) => {
+          expect(err).to.equal(undefined);
+          expect(val.statusCode).to.equal(201);
+          expect(val.headers.location).to.equal('201/request/1');
+          done1();
+        });
 
-    // Send an HTTP request, expecting an error message
-    brequest.post('http://localhost::p/:v/:r', { p: server.address().port,
-      v: 'err', r: 'request', body: 'duh' }, (err, val) => {
-        expect(err.message).to.equal('duh');
-        expect(val).to.equal(undefined);
-        done1();
-    });
-    */
+      // Send an HTTP request, expecting a 500 status code
+      // Here test the option to pass the URI as a field of the options object
+      brequest.post({ uri: 'http://localhost::p/:v/:r',
+        p: server.address().port, v: '500', r: 'request' }, (err, val) => {
+          expect(err.message).to.equal('HTTP response status code 500');
+          expect(val).to.equal(undefined);
+          done1();
+        });
+
+      // Send an HTTP request, expecting an error message
+      brequest.post('http://localhost::p/:v/:r', { p: server.address().port,
+        v: 'err', r: 'request', body: 'duh' }, (err, val) => {
+          expect(err.message).to.equal('duh');
+          expect(val).to.equal(undefined);
+          done1();
+        });
     });
   });
 
-});
+  it('batches HTTP request to an invalid URL', (done) => {
+    // Create a test HTTP server
+    const server = http.createServer((req, res) => {
+      if (req.url === '/batch') {
+        // Return 404
+        res.statusCode = 404;
+        res.setHeader('Content-type', 'application/json');
+        res.end(JSON.stringify({ error: 'Not found' }));
+      }
+    });
 
+    // Listen on an ephemeral port
+    server.listen(0);
+
+    // Wait for the server to become available
+    request.waitFor('http://localhost::p/batch', {
+      p: server.address().port
+    }, (err, val) => {
+      if(err)
+        throw err;
+
+      // Use a batch version of the request module
+      const brequest = batch(request);
+
+      // Send an HTTP request, expecting a 404 response
+      brequest.get('http://localhost::p/:v/:r', {
+        cache: true,
+        p: server.address().port,
+        v: 'notfound',
+        r: 'request'
+      }, (err, val) => {
+        expect(err).to.equal(undefined);
+        expect(val.statusCode).to.equal(404);
+        expect(val.body).to.deep.equal({ error: 'Not found' });
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
When a server responds with a 404 for a batch request, batch request expects
the response to be in a standardized batch response format with an array of
responses. In the case of 404, Map the non-standard response to individual
responses.

Fixes [Finishes #102364254] at Pivotal Tracker.
