### PR TITLE
Fix batch middleware to handle exceptions

### DIFF
--- a/lib/utils/router/src/index.js
+++ b/lib/utils/router/src/index.js
@@ -182,9 +182,10 @@ const batch = (routes) => {
       });
 
       // Call the given router
-      routes(rreq, rres, () => {
-        if(rres.value)
-          return rcb(undefined, rres.value);
+      routes(rreq, rres, (err) => {
+        if (err) return rcb(err);
+
+        if(rres.value) return rcb(undefined, rres.value);
         next();
       });
 

--- a/lib/utils/router/src/test/test.js
+++ b/lib/utils/router/src/test/test.js
@@ -279,5 +279,43 @@ describe('abacus-router', () => {
       done1();
     });
   });
-});
 
+  it('handles unhandled exceptions at middleware and' +
+    'responds back with a 500 for a batch http request', (done) => {
+      // Create a test Express app
+      const app = express();
+
+      // Create a router
+      const routes = router();
+
+      // Add a test route that throws an exception
+      routes.get('/exception/request', (req, res) => {
+        if (req.cause.unhandled.exception)
+          res.status(200).send({ message: '' });
+      });
+
+      // Add our router to the app
+      app.use(routes);
+
+      // Add batch router middleware to the app
+      app.use(router.batch(routes));
+
+      // Listen on an ephemeral port
+      const server = app.listen(0);
+
+      // Use a batch version of the request module
+      const brequest = batch(request);
+
+      // Send an HTTP request, expecting a 500 status code
+      brequest.get({
+        uri: 'http://localhost::p/:v/:r',
+        p: server.address().port,
+        v: 'exception',
+        r: 'request'
+      }, (err, val) => {
+        expect(err.message).to.equal('HTTP response status code 500');
+        expect(val).to.equal(undefined);
+        done();
+      });
+    });
+});


### PR DESCRIPTION
When there is an exception at a middleware, batch middleware ignores the
exception and lets the server respond back with a 404. Handle the exception
and respond back with a 500 instead.

Fix [Finishes #102368074] at Pivotal Tracker.
