### PR TITLE
Add usage aggregator integration and performance test

### DIFF
--- a/test/aggregation/aggregator/.gitignore
+++ b/test/aggregation/aggregator/.gitignore
@@ -1,0 +1,2 @@
+lib/**
+node_modules/**

--- a/test/aggregation/aggregator/.npmrc
+++ b/test/aggregation/aggregator/.npmrc
@@ -1,0 +1,1 @@
+optional=false

--- a/test/aggregation/aggregator/README.md
+++ b/test/aggregation/aggregator/README.md
@@ -1,0 +1,4 @@
+abacus-usage-aggregator-itest
+===
+
+Usage aggregator integration and performance tests.

--- a/test/aggregation/aggregator/package.json
+++ b/test/aggregation/aggregator/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "abacus-usage-aggregator-itest",
+  "description": "Usage aggregator integration and performance tests",
+  "license": "Apache-2.0",
+  "version": "0.0.1-dev.3",
+  "private": true,
+  "homepage": "https://github.com/cloudfoundry-incubator/cf-abacus/test/aggregation/aggregator",
+  "bugs": {
+    "url": "https://github.com/cloudfoundry-incubator/cf-abacus/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/cloudfoundry-incubator/cf-abacus.git"
+  },
+  "keywords": [
+    "cf",
+    "abacus"
+  ],
+  "files": [
+    ".npmrc",
+    "lib/",
+    "src/"
+  ],
+  "main": "lib/index.js",
+  "scripts": {
+    "itest": "mocha --command",
+    "babel": "babel",
+    "test": "eslint",
+    "lint": "eslint",
+    "pub": "publish"
+  },
+  "dependencies": {
+    "abacus-mocha": "file:../../../tools/mocha",
+    "abacus-batch": "file:../../../lib/utils/batch",
+    "abacus-throttle": "file:../../../lib/utils/throttle",
+    "abacus-request": "file:../../../lib/utils/request",
+    "abacus-router": "file:../../../lib/utils/router",
+    "abacus-express": "file:../../../lib/utils/express",
+    "abacus-dbserver": "file:../../../lib/utils/dbserver",
+    "abacus-usage-aggregator": "file:../../../lib/aggregation/aggregator",
+    "abacus-debug": "file:../../../lib/utils/debug",
+    "underscore": "^1.8.3",
+    "commander": "2.8.1"
+  },
+  "devDependencies": {
+    "abacus-babel": "file:../../../tools/babel",
+    "abacus-eslint": "file:../../../tools/eslint",
+    "abacus-publish": "file:../../../tools/publish"
+  },
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">=2.0.0"
+  }
+}

--- a/test/aggregation/aggregator/src/index.js
+++ b/test/aggregation/aggregator/src/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+// There is nothing here - see test/test.js for the integration and
+// performance tests.
+

--- a/test/aggregation/aggregator/src/test/test.js
+++ b/test/aggregation/aggregator/src/test/test.js
@@ -1,0 +1,305 @@
+'use strict';
+
+const cp = require('child_process');
+const _ = require('underscore');
+
+const commander = require('commander');
+
+const batch = require('abacus-batch');
+const throttle = require('abacus-throttle');
+const request = require('abacus-request');
+const router = require('abacus-router');
+const express = require('abacus-express');
+
+const map = _.map;
+const range = _.range;
+const clone = _.clone;
+const omit = _.omit;
+
+// Batch the requests
+const brequest = batch(request);
+
+// Setup the debug log
+const debug = require('abacus-debug')('abacus-usage-aggregator-itest');
+
+// Parse command line options
+const argv = clone(process.argv);
+argv.splice(1, 1, 'usage-aggregator-itest');
+commander
+  .option('-o, --orgs <n>', 'number of organizations', parseInt)
+  .option('-i, --instances <n>', 'number of resource instances', parseInt)
+  .option('-u, --usagedocs <n>', 'number of usage docs', parseInt)
+  .option('-d, --day <d>',
+    'usage time shift using number of days', parseInt)
+  .allowUnknownOption(true)
+  .parse(argv);
+
+// Number of organizations
+const orgs = commander.orgs || 1;
+
+// Number of resource instances
+const resourceInstances = commander.instances || 1;
+
+// Number of usage docs
+const usage = commander.usagedocs || 1;
+
+// Usage time shift by number of days in milli-seconds
+const tshift = commander.day * 24 * 60 * 60 * 1000 || 0;
+
+// Return the aggregation start time for a given time
+const day = (t) => {
+  const d = new Date(t);
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+};
+
+// Return the aggregation end time for a given time
+const eod = (t) => {
+  const d = new Date(t);
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(),
+    d.getUTCDate() + 1) - 1;
+};
+
+// Format an object properties using a format function
+const format = (o, f) => {
+  map(o, (v, k) => { o[k] = f(k, v); });
+  return o;
+};
+
+// Aggregated usage format function
+const formatAggregated = (k, v) => {
+  if (k === 'aggregated_usage') return map(v, (u) => {
+    // Warning: mutating usage to get quantity in a
+    // comparable format
+    if (u.metric === 'thousand_light_api_calls')
+      u.quantity = u.quantity.toFixed(2);
+    return u;
+  });
+  if(typeof v === 'object') return format(v, formatAggregated);
+  return v;
+};
+
+// Module directory
+const moduleDir = (module) => {
+  const path = require.resolve(module);
+  return path.substr(0, path.indexOf(module + '/') + module.length);
+};
+
+describe('abacus-usage-accumulator-itest', () => {
+  before(() => {
+    const start = (module) => {
+      const c = cp.spawn('npm', ['run', 'start'],
+        { cwd: moduleDir(module), env: clone(process.env) });
+
+      // Add listeners to stdout, stderr and exit messsage and forward the
+      // messages to debug logs
+      c.stdout.on('data', (d) => process.stdout.write(d));
+      c.stderr.on('data', (d) => process.stderr.write(d));
+      c.on('exit', (c) => debug('Application exited with code %d', c));
+    };
+
+    // Start local database server
+    start('abacus-dbserver');
+
+    // Start usage accumulator
+    start('abacus-usage-aggregator');
+  });
+
+  after(() => {
+    const stop = (module) => {
+      cp.spawn('npm', ['run', 'stop'],
+        { cwd: moduleDir(module), env: clone(process.env) });
+    };
+
+    // Stop usage accumulator
+    stop('abacus-usage-aggregator');
+
+    // Stop local database server
+    stop('abacus-dbserver');
+  });
+
+  it('aggregate accumulated usage submissions', function(done) {
+    // Configure the test timeout based on the number of usage docs, with
+    // a minimum of 20 secs
+    const timeout = Math.max(20000,
+      100 * orgs * resourceInstances * usage);
+    this.timeout(timeout + 2000);
+
+    // Setup rate spy
+    const rate = spy((req, res, next) => { res.status(201).send(); });
+
+    // Start usage rate stub with the aggregator spy
+    const app = express();
+    const routes = router();
+    routes.post('/v1/rating/usage', rate);
+    app.use(routes);
+    app.use(router.batch(routes));
+    app.listen(9410);
+
+    // Initialize usage doc properties with unique values
+    const start = 1435629365220 + tshift;
+    const end = 1435629465220 + tshift;
+
+    const oid = (o) => ['a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
+      o + 1].join('-');
+    const sid = (o, ri) => ['aaeae239-f3f8-483c-9dd0-de5d41c38b6a',
+      o + 1].join('-');
+    const cid = (o, ri) => ['bbeae239-f3f8-483c-9dd0-de6781c38bab',
+      o + 1].join['-'];
+    const pid = (ri, u) => 'basic';
+
+    const riid = (o, ri) => ['0b39fa70-a65f-4183-bae8-385633ca5c87',
+      o + 1, ri + 1].join('-');
+
+    const uid = (o, ri, u) => [start, o + 1, ri + 1, u + 1].join('-');
+    const bid = (u) => [start, u + 1].join('-');
+
+    // Accumulated usage for given org, resource instance and usage #s
+    const accumulatedTemplate = (o, ri, u) => ({
+      usage_id: uid(o, ri, u),
+      usage_batch_id: bid(u),
+      metered_usage_id: uid(o, ri, u),
+      resource_id: 'object-storage',
+      resource_instance_id: riid(o, ri),
+      start: start + u,
+      end: end + u,
+      plan_id: pid(ri, u),
+      region: 'us-south',
+      organization_id: oid(o),
+      space_id: sid(o, ri),
+      consumer: { type: 'external', value: cid(o, ri) },
+      measured_usage: [
+        { measure: 'storage', quantity: 1073741824 },
+        { measure: 'light_api_calls', quantity: 10 },
+        { measure: 'heavy_api_calls', quantity: 20 }
+      ],
+      accumulated_usage: [
+        { delta: u === 0 ? 1 : 0, metric: 'storage', quantity: 1 },
+        { delta: 0.01, metric: 'thousand_light_api_calls',
+          quantity: 0.01 * (u + 1)
+        },
+        { delta: 20, metric: 'heavy_api_calls', quantity: 20 * (u + 1) }
+      ]
+    });
+
+    // Aggregated usage
+    const aggregated = (o, ri, u) => [
+      { metric: 'storage',
+        quantity: ri < resourceInstances && u === 0 ?
+        ri + 1 : resourceInstances },
+      { metric: 'thousand_light_api_calls',
+        quantity: (0.01 * (ri + 1 + u * resourceInstances)).toFixed(2) },
+      { metric: 'heavy_api_calls',
+        quantity: 20 * (ri + 1 + u * resourceInstances) }
+    ];
+
+    // Plan aggregated usage
+    const paggregated = (o, ri, u) => [{
+      plan_id: pid(ri, u),
+      aggregated_usage: aggregated(o, ri, u)
+    }];
+
+    // Aggregated usage for a given org, resource instance, usage #s
+    const aggregatedTemplate = (o, ri, u) => ({
+      organization_id: oid(o),
+      start: day(end + u),
+      end: eod(end + u),
+      resources: [{
+        resource_id: 'object-storage',
+        aggregated_usage: aggregated(o, ri, u),
+        plans: paggregated(o, ri, u)
+      }],
+      spaces: [{
+        space_id: sid(o, ri),
+        resources: [{
+          resource_id: 'object-storage',
+          aggregated_usage: aggregated(o, ri, u),
+          plans: paggregated(o, ri, u)
+        }],
+        consumers: [{
+          resources: [{
+            resource_id: 'object-storage',
+            aggregated_usage: aggregated(o, ri, u),
+            plans: paggregated(o, ri, u)
+          }]
+        }]
+      }]
+    });
+
+    // Post an accumulated usage doc, throttled to default concurrent requests
+    const post = throttle((o, ri, u, cb) => {
+      debug('Submit accumulated usage for org%d instance%d usage%d',
+        o + 1, ri + 1, u + 1);
+
+      brequest.post('http://localhost::p/v1/metering/accumulated/usage',
+        { p: 9200, body: accumulatedTemplate(o, ri, u) }, (err, val) => {
+          expect(err).to.equal(undefined);
+          expect(val.statusCode).to.equal(201);
+          expect(val.headers.location).to.not.equal(undefined);
+
+          debug('Aggregated accumulated usage for org%d instance%d' +
+            'usage%d, verifying it...', o + 1, ri + 1, u + 1);
+
+          brequest.get(val.headers.location, undefined, (err, val) => {
+            debug('Verify aggregated usage for org%d instance%d usage%d',
+              o + 1, ri + 1, u + 1);
+
+            expect(err).to.equal(undefined);
+            expect(val.statusCode).to.equal(200);
+
+            // Format aggregated usage before doing a comparision, as thousand
+            // light api calls has problem with fractions
+            expect(format(omit(val.body, ['id']), formatAggregated)).to.deep
+              .equal(aggregatedTemplate(o, ri, u));
+
+            debug('Verified aggregated usage for org%d instance%d usage%d',
+              o + 1, ri + 1, u + 1);
+
+            cb();
+          });
+        });
+    });
+
+    // Post the requested number of accumulated usage docs
+    const submit = (done) => {
+      let posts = 0;
+      const cb = () => {
+        if(++posts === orgs * resourceInstances * usage) done();
+      };
+
+      // Submit usage for all orgs and resource instances
+      map(range(usage), (u) => map(range(resourceInstances),
+        (ri) => map(range(orgs), (o) => post(o, ri, u, cb))));
+    };
+
+    let retries = 0;
+    const verifyRating = (done) => {
+      try {
+        debug('Verifying rating calls %d to equal to %d',
+          rate.callCount, orgs * resourceInstances * usage);
+
+        expect(rate.callCount).to.equal(orgs * resourceInstances * usage);
+        done();
+      }
+      catch (e) {
+        // If the comparison fails we'll be called again to retry
+        // after 250 msec, but give up after 10 seconds
+        if(++retries === 40) throw e;
+
+        debug('Retry#%d', retries);
+      }
+    };
+
+    // Wait for usage aggregator to start
+    request.waitFor('http://localhost::p/batch',
+      { p: 9200 }, (err, value) => {
+        // Failed to ping usage aggregator before timing out
+        if (err) throw err;
+
+        // Submit accumulated usage and Verify
+        submit(() => {
+          const i = setInterval(() =>
+            verifyRating(() => done(clearInterval(i))), 250);
+        });
+      });
+  });
+});


### PR DESCRIPTION
End to end test for usage aggregator. Use the same for performance
measurements. Run npm run itest -- -h for more details.

Supports a plan, a space and a consumer level aggregations. Need to
enhance it to support more than one plan, space, and consumer.

See tracker [#101021756].
