### PR TITLE
Increase request ping timeout to 10 seconds

### DIFF
--- a/lib/utils/request/src/index.js
+++ b/lib/utils/request/src/index.js
@@ -373,12 +373,12 @@ const waitFor = (uri, opt, cb) => {
     }
   }, 250);
 
-  // Time out after 5 sec
+  // Time out after 10 seconds
   const to = setTimeout(() => {
     debug('Timed out');
     clearInterval(i);
     t.callback(new Error('timeout'));
-  }, 5000);
+  }, 10000);
 };
 
 // Export our public functions


### PR DESCRIPTION
Usage aggregator and accumulator take more than 5 seconds to start on a local
machine. Increase the ping timeout to 10 seconds to avoid random timeout
exceptions when running integration tests.
