### PR TITLE
Expand usage aggregator integration test scope

### DIFF
--- a/test/aggregation/aggregator/src/test/test.js
+++ b/test/aggregation/aggregator/src/test/test.js
@@ -120,18 +120,50 @@ describe('abacus-usage-aggregator-itest', () => {
     const start = 1435629365220 + tshift;
     const end = 1435629465220 + tshift;
 
+    // Produce usage for two spaces in an organization, two consumers
+    // in a space and create resource instances using two resource plans
+    // at each space.
+
+    // Usage template index values for a given org
+    //  Usage  ResourceInstance  Space Plan Consumer(with space)
+    //    0           0            0    0        0-0
+    //    0           1            1    0        1-0
+    //    0           2            0    1        0-0
+    //    0           3            1    1        1-0
+    //    0           4            0    0        0-1
+    //    0           5            1    0        1-1
+    //    0           6            0    1        0-1
+    //    0           7            1    1        1-1
+    //    0           8            0    0        0-0
+    //    0           9            1    0        1-0
+    //    0          10            0    1        0-0
+    //    1           0            0    0        0-0
+    //    1           1            1    0        1-0
+
+    // Organization id based on org index
     const oid = (o) => ['a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
       o + 1].join('-');
-    const rid = (o) => o % 2 === 0 ? 'us-south' : 'eu-gb';
-    const sid = (o, ri) => ['aaeae239-f3f8-483c-9dd0-de5d41c38b6a',
-      o + 1].join('-');
-    const cid = (o, ri) => ['bbeae239-f3f8-483c-9dd0-de6781c38bab',
-      o + 1].join('-');
-    const pid = (ri, u) => 'basic';
 
+    // One of the two regions based on an org index
+    const rid = (o) => o % 2 === 0 ? 'us-south' : 'eu-gb';
+
+    // One of the two spaces at a given org based on resource instance index
+    const sid = (o, ri) => ['aaeae239-f3f8-483c-9dd0-de5d41c38b6a',
+      o + 1, ri % 2 === 0 ? 1 : 2].join('-');
+
+    // One of the two consumers at a given org and derived space based on
+    // resource instance index
+    const cid = (o, ri) => ['bbeae239-f3f8-483c-9dd0-de6781c38bab',
+      o + 1, ri % 2 === 0 ? 1 : 2, ri % 8 < 4 ? 1 : 2].join('-');
+
+    // One of the two plans based on resource instance index
+    const pid = (ri) => ri % 4 < 2 ? 'basic' : 'advanced';
+
+    // Resource instance id based on org and resouce instance indices
     const riid = (o, ri) => ['0b39fa70-a65f-4183-bae8-385633ca5c87',
       o + 1, ri + 1].join('-');
 
+    // Usage and usage batch ids
     const uid = (o, ri, u) => [start, o + 1, ri + 1, u + 1].join('-');
     const bid = (u) => [start, u + 1].join('-');
 
@@ -181,24 +213,150 @@ describe('abacus-usage-aggregator-itest', () => {
       ]
     });
 
-    // Aggregated usage
-    const aggregated = (o, ri, u) => [
-      { metric: 'storage',
-        quantity: ri < resourceInstances && u === 0 ?
-        ri + 1 : resourceInstances },
+    // Use number sequences to find expected aggregated value at any given
+    // resource instance index and a given usage index based on the generated
+    // accumulated usage.
+
+    // Total resource instances index
+    const tri = resourceInstances - 1;
+
+    // Create an array of objects based on a range and a creator function
+    const create = (number, creator) =>
+      map(range(number()), (i) => creator(i));
+
+    // Aggregate metrics based on ressource instance, usage and plan indices
+    // For max, we use either the current count or the totat count based on
+    // resource instance index
+    // For sum, we use current count + total count based on resource instance
+    // and usage index
+    const a = (ri, u, p, count) => [
+      { metric: 'storage', quantity: u === 0 ? count(ri, p) : count(tri, p) },
       { metric: 'thousand_light_api_calls',
-        quantity: ri + 1 + u * resourceInstances },
+        quantity: count(ri, p) + u * count(tri, p) },
       { metric: 'heavy_api_calls',
-        quantity: 100 * (ri + 1 + u * resourceInstances) }
+        quantity: 100 * (count(ri, p) + u * count(tri, p)) }
     ];
 
-    // Plan aggregated usage
-    const paggregated = (o, ri, u) => [{
-      plan_id: pid(ri, u),
-      aggregated_usage: aggregated(o, ri, u)
-    }];
+    // Resouce plan level aggregations for a given consumer at given space
+    const scpagg = (o, ri, u, s, c) => {
+      // Resource instance index shift to locate a value at count number
+      // sequence specified below
+      const shift = (p) =>
+        (s === 0 ? c === 0 ? 8 : 4 : c === 0 ? 7 : 3) - (p === 0 ? 0 : 2);
 
-    // Aggregated usage for a given org, resource instance, usage #s
+      // Number sequence representing count for a given space, consumer and
+      // plan based on specified spread using id generators
+      // 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1,
+      // 2, 2, 2, 2, 2, 2, 2, 2, 3, ......
+      const count = (n, p) => Math.round((n + shift(p)) / 8 - 0.50);
+
+      // Number of plans at a given space, consumer and
+      // resource instance indices
+      const plans = () => u === 0 && ri <= (c === 0 ? 1 + s : 5 + s) ||
+        tri <= (c === 0 ? 1 + s : 5 + s) ? 1 : 2;
+
+      // Create plan aggregations
+      return create(plans, (i) => ({
+          plan_id: pid(i === 0 ? 0 : 2),
+          aggregated_usage: a(ri, u, i, count)
+        }));
+    };
+
+    // Consumer level resource aggregations for a given space
+    const scagg = (o, ri, u, s) => {
+      // Resource instance index shift
+      const shift = (c) => (s === 0 ? 6 : 5) - (c === 0 ? 0 : 4);
+
+      // Number sequence of count
+      // 0, 0, 0, 0, 0, 0, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 4, 4, 4, 4, 4, 4,
+      // 5, 5, 6, .....
+      const count = (n, c) => {
+        const nri = n + shift(c);
+        return 2 * Math.round(nri / 8 - 0.50) + (nri % 8 < 6 ? 0 : 1);
+      };
+
+      // Number of consumers at a given resource instance and space indices
+      const consumers = () => u === 0 && ri <= 3 + s || tri <= 3 + s ? 1 : 2;
+
+      // Create resource aggregations
+      return create(consumers, (i) => ({
+        consumer_id: cid(o, i === 0 ? s : s === 0 ? 4 : 5),
+        resources: [{
+          resource_id: 'test-resource',
+          aggregated_usage: a(ri, u, i, count),
+          plans: scpagg(o, ri, u, s, i)
+        }]
+      }));
+    };
+
+    // Resource plan level aggregations for a given space
+    const spagg = (o, ri, u, s) => {
+      // resource instance index shift
+      const shift = (p) => (s === 0 ? 3 : 2) - (p === 0 ? 0 : 2);
+
+      // Number sequence of count
+      // 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, ......
+      const count = (n, p) => Math.round((n + shift(p)) / 4 - 0.25);
+
+      // Number of plans at a given resource instance and space indices
+      const plans = () => u === 0 && ri <= 1 + s || tri <= 1 + s ? 1 : 2;
+
+      // Create plan level aggregations
+      return create(plans, (i) => ({
+        plan_id: pid(i === 0 ? 0 : 2),
+        aggregated_usage: a(ri, u, i, count)
+      }));
+    };
+
+    // Space level resource aggregations for a given organization
+    const osagg = (o, ri, u) => {
+      // Resource instance index shift
+      const shift = (s) => s === 0 ? 1 : 0;
+
+      // Number sequnce of count
+      // 0, 1, 1, 2, 2, 3, 3, 4, 4,.....
+      const count = (n, s) => Math.round((n + shift(s)) / 2);
+
+      // Number of spaces at a given resource index
+      const spaces = () => u === 0 && ri === 0 || tri === 0 ? 1 : 2;
+
+      // Create resource instance aggregations
+      return create(spaces, (i) => ({
+        space_id: sid(o, i),
+        resources: [{
+          resource_id: 'test-resource',
+          aggregated_usage: a(ri, u, i, count),
+          plans: spagg(o, ri, u, i)
+        }],
+        consumers: scagg(o, ri, u, i)
+      }));
+    };
+
+    // Resource plan level aggregations for a given organization
+    const opagg = (o, ri, u) => {
+      // Resource instance index shift
+      const shift = (p) => p === 0 ? 2 : 0;
+
+      // Number sequence of count
+      // 0, 0, 1, 2, 2, 2, 3, 4, 4, 4, 5, 6, 6, 6, 7, 8, 8, 8, ...........
+      const count = (n, p) => {
+        const nri = n + shift(p);
+
+        return Math.round(nri / 2 +
+          (nri % 2 === 0 ? 0 : 0.5) * ((nri / 2 - 0.5) % 2 === 0 ? -1 : 1));
+      };
+
+      // Number of plans at a given resource instance index
+      const plans = () => u === 0 && ri <= 1 || tri <= 1 ? 1 : 2;
+
+      // Create plan aggregations
+      return create(plans, (i) => ({
+        plan_id: pid(i === 0 ? 0 : 2),
+        aggregated_usage: a(ri, u, i, count)
+      }));
+    };
+
+    // Aggregated usage for a given org, resource instance, usage indices
     const aggregatedTemplate = (o, ri, u) => ({
       accumulated_usage_id: uid(o, ri, u),
       organization_id: oid(o),
@@ -206,25 +364,10 @@ describe('abacus-usage-aggregator-itest', () => {
       end: eod(end + u),
       resources: [{
         resource_id: 'test-resource',
-        aggregated_usage: aggregated(o, ri, u),
-        plans: paggregated(o, ri, u)
+        aggregated_usage: a(ri, u, undefined, (n) => n + 1),
+        plans: opagg(o, ri, u)
       }],
-      spaces: [{
-        space_id: sid(o, ri),
-        resources: [{
-          resource_id: 'test-resource',
-          aggregated_usage: aggregated(o, ri, u),
-          plans: paggregated(o, ri, u)
-        }],
-        consumers: [{
-          consumer_id: cid(o, ri),
-          resources: [{
-            resource_id: 'test-resource',
-            aggregated_usage: aggregated(o, ri, u),
-            plans: paggregated(o, ri, u)
-          }]
-        }]
-      }]
+      spaces: osagg(o, ri, u)
     });
 
     // Post an accumulated usage doc, throttled to default concurrent requests


### PR DESCRIPTION
Convert accumulated usage template to produce usage for two spaces in an
organization, two consumers in a space and create resource instances using
two resource plans at each space.

Use number sequences to find expected aggregated value at any given resource
instance index and a given usage index based on the generated accumulated
usage.
