### PR TITLE
Mock batch module to avoid timing issues with aggregator unit tests

### DIFF
--- a/lib/aggregation/aggregator/src/test/test.js
+++ b/lib/aggregation/aggregator/src/test/test.js
@@ -3,13 +3,20 @@
 // Usage aggregator service.
 
 const _ = require('underscore');
+
+const yieldable = require('abacus-yieldable');
+
 const request = require('abacus-request');
 const cluster = require('abacus-cluster');
 
 const map = _.map;
-const omit = _.omit;
-const extend = _.extend;
+const initial = _.initial;
+const last = _.last;
 const clone = _.clone;
+const extend = _.extend;
+const omit = _.omit;
+const identity = _.identity;
+const isFunction = _.isFunction;
 
 // Configure test db URL prefix
 process.env.COUCHDB = process.env.COUCHDB || 'test';
@@ -22,9 +29,23 @@ require.cache[require.resolve('abacus-cluster')].exports =
 
 // Mock the request module
 const reqmock = extend(clone(request), {
-  batch_noWaitPost: spy((reqs, cb) => cb())
+  noWaitPost: spy((uri, req, cb) => cb())
 });
 require.cache[require.resolve('abacus-request')].exports = reqmock;
+
+require('abacus-batch');
+const mockbatchfn = (fn) => {
+  const fcb = yieldable.functioncb(fn);
+  return function() {
+    const call = map(arguments, identity);
+    fcb([initial(call)], (err, val) => {
+      last(call).apply(undefined, err ? [err] : val[0]);
+    });
+  };
+};
+
+require.cache[require.resolve('abacus-batch')].exports =
+  spy((fn, timeout) => isFunction(fn) ? mockbatchfn(fn) : fn);
 
 const aggregator = require('..');
 
@@ -762,19 +783,17 @@ describe('abacus-usage-aggregator', () => {
 
     // Check posts to the rating service
     const checkrating = (done) => {
-      setTimeout(() => {
-        // Expect usage docs to have been posted to the rating service
-        expect(reqmock.batch_noWaitPost.args.length).to.equal(1);
-        expect(reqmock.batch_noWaitPost.args[0][0][0][0]).to.equal(
-          'http://localhost:9410/v1/rating/usage');
-        expect(reqmock.batch_noWaitPost.args[0][0][1][0]).to.equal(
-          'http://localhost:9410/v1/rating/usage');
-        expect(reqmock.batch_noWaitPost.args[0][0][2][0]).to.equal(
-          'http://localhost:9410/v1/rating/usage');
-        expect(reqmock.batch_noWaitPost.args[0][0][3][0]).to.equal(
-          'http://localhost:9410/v1/rating/usage');
-        done();
-      }, 500);
+      // Expect usage docs to have been posted to the rating service
+      expect(reqmock.noWaitPost.args.length).to.equal(4);
+      expect(reqmock.noWaitPost.args[0][0]).to.equal(
+        'http://localhost:9410/v1/rating/usage');
+      expect(reqmock.noWaitPost.args[1][0]).to.equal(
+        'http://localhost:9410/v1/rating/usage');
+      expect(reqmock.noWaitPost.args[2][0]).to.equal(
+        'http://localhost:9410/v1/rating/usage');
+      expect(reqmock.noWaitPost.args[3][0]).to.equal(
+        'http://localhost:9410/v1/rating/usage');
+      done();
     };
 
     // Get the aggregated usage history


### PR DESCRIPTION
Mock batch module to convert batch function calls to call original function
without batching.

Fixes aggregator unit tests related to issue #26.

Also see tracker [#103260976].
