### PR TITLE
Use correct resource plans at integration tests

### DIFF
--- a/test/aggregation/aggregator/src/test/test.js
+++ b/test/aggregation/aggregator/src/test/test.js
@@ -215,7 +215,7 @@ describe('abacus-usage-aggregator-itest', () => {
       o + 1, ri % 2 === 0 ? 1 : 2, ri % 8 < 4 ? 1 : 2].join('-');
 
     // One of the two plans based on resource instance index
-    const pid = (ri) => ri % 4 < 2 ? 'basic' : 'advanced';
+    const pid = (ri) => ri % 4 < 2 ? 'basic' : 'standard';
 
     // Resource instance id based on org and resouce instance indices
     const riid = (o, ri) => ['0b39fa70-a65f-4183-bae8-385633ca5c87',


### PR DESCRIPTION
The test-resource has basic and standard plans with different price
structures. Use them at usage aggregator and usage rating service
integration and performance tests.

Add more comments to usage rating service integration tests.

See tracker [#103216578].
