### PR TITLE
Increase default circuit breaker call timeout from 5 secs to 20 secs

### DIFF
--- a/lib/utils/breaker/src/index.js
+++ b/lib/utils/breaker/src/index.js
@@ -25,13 +25,13 @@ const bind = _.bind;
 const debug = require('abacus-debug')('abacus-breaker');
 
 // Circuit breaker options, with the following defaults:
-// timeout a call after 10 secs,
-// 20 calls must occur in 10 secs before stats matter,
+// timeout a call after 20 secs,
+// 10 calls must occur in 10 secs before stats matter,
 // trip circuit when 50% calls are failures or latent,
 // sleep 5 secs before trying again a tripped circuit
 const options = (callTimeout, callThreshold, errorPercentage, resetTimeout) => {
   return {
-    timeout: callTimeout || 5000,
+    timeout: callTimeout || 20000,
     threshold: callThreshold || 10,
     errors: errorPercentage || 50,
     reset: resetTimeout || 5000

--- a/lib/utils/breaker/src/test/test.js
+++ b/lib/utils/breaker/src/test/test.js
@@ -109,15 +109,15 @@ describe('abacus-breaker', () => {
     const sum = function sum(x, y, cb) {
       setTimeout(() => {
         cb(undefined, x + y);
-      }, 20000);
+      }, 40000);
     };
     const b = breaker(sum);
     b(3, 2, cb);
 
     // Expect the callback to be passed a timeout error
-    clock.tick(5500);
+    clock.tick(20500);
     expect(cb.args.length).to.equal(1);
-    const terr = new breaker.TimeoutError('sum', 5000);
+    const terr = new breaker.TimeoutError('sum', 20000);
     expect(cb.args[0]).to.deep.equal([terr, undefined]);
   });
 


### PR DESCRIPTION
Couch database operations do take more than 5 seconds to complete. To avoid
timing out database calls, increase the default call timeout value from
5 seconds to 20 seconds.

See tracker [#103216578]
