### PR TITLE
Fix _id, dbrev, and _rev issues across the board.

### DIFF
--- a/lib/aggregation/accumulator/src/index.js
+++ b/lib/aggregation/accumulator/src/index.js
@@ -216,7 +216,7 @@ const updateAccumulatedUsage =
       let newa = omit(a, 'last_accumulated_usage_id');
       const ares = map(calls, (call) => {
         newa = accumulate(newa, call[0].u, call[0].u);
-        return [undefined, newa];
+        return [undefined, omit(newa, 'dbrev')];
       });
 
       // Store the final accumulated usage
@@ -254,7 +254,7 @@ const accumulateUsage = function *(u) {
     u: u, aid: aid, alogid: alogid, ulogid: ulogid });
 
   // Post the new accumulated usage to the target aggregator partition
-  const alogdoc = extend(omit(newa, ['dbrev', '_rev']), {
+  const alogdoc = extend(dbclient.undbify(newa), {
     id: alogid,
     processed_usage_id: ulogid
   });
@@ -306,7 +306,7 @@ routes.get(
         req.params.day, req.params.seq
       ].join('/'));
     debug('Retrieving accumulated usage for id %s', id);
-    const doc = omit(yield logdb.get(id), ['_id', '_rev']);
+    const doc = dbclient.undbify(yield logdb.get(id));
 
     return { body: doc };
   }));

--- a/lib/aggregation/aggregator/src/index.js
+++ b/lib/aggregation/aggregator/src/index.js
@@ -313,7 +313,7 @@ const updateAggregatedUsage =
         newa = extend(newa,
           { start: day(call[0].u.end), end: eod(call[0].u.end) });
         newa = aggregate(newa, call[0].u);
-        return [undefined, newa];
+        return [undefined, omit(newa, 'dbrev')];
       });
 
       // Store the final new aggregated usage
@@ -342,7 +342,7 @@ const aggregateUsage = function *(u) {
     u: u, aid: aid, alogid: alogid, uid: uid });
 
   // Log the new aggregated usage
-  const alogdoc = extend(omit(newa, ['dbrev', '_rev']), {
+  const alogdoc = extend(dbclient.undbify(newa), {
     id: alogid,
     accumulated_usage_id: u.id
   });
@@ -393,7 +393,7 @@ routes.get(
     debug('Retrieving aggregated usage for id %s', id);
 
     // Retrieve and return the aggregated usage doc
-    const doc = omit(yield logdb.get(id), ['_id', '_rev']);
+    const doc = dbclient.undbify(yield logdb.get(id));
     return {
       body: doc
     };

--- a/lib/aggregation/rate/src/index.js
+++ b/lib/aggregation/rate/src/index.js
@@ -139,10 +139,6 @@ const rate = (r, u, pc) => {
     })
   });
 
-  // Use db and cache revisions from last rated usage
-  if(r)
-    extend(newr,
-      r.dbrev ? { dbrev: r.dbrev, _rev: r._rev } : { _rev: r._rev });
   debug('New rated usage %o', newr);
   return newr;
 };
@@ -216,7 +212,7 @@ const updateRatedUsage =
       // Rate the usage docs
       const rres = map(calls, (call) => {
         newr = rate(newr, call[0].u, pc);
-        return [undefined, newr];
+        return [undefined, omit(newr, 'dbrev')];
       });
 
       // Store the final new rated usage
@@ -245,7 +241,7 @@ const rateUsage = function *(u) {
     u: u, rid: rid, rlogid: rlogid, uid: u.id });
 
   // Log the rated usage
-  const rlogdoc = extend(omit(newr, ['dbrev', '_rev']), {
+  const rlogdoc = extend(dbclient.undbify(newr), {
     id: rlogid,
     aggregated_usage_id: u.id
   });
@@ -289,8 +285,8 @@ routes.get(
     debug('Retrieving rated usage for id %s', id);
 
     // Retrieve and return the metered usage doc without _id and _rev
-    const doc = omit(yield logdb.get(id),
-      ['_id', '_rev', 'last_rated_usage_id']);
+    const doc = omit(dbclient.undbify(yield logdb.get(id)),
+      'last_rated_usage_id');
 
     // return the doc as response body
     return {

--- a/lib/aggregation/reporting/src/index.js
+++ b/lib/aggregation/reporting/src/index.js
@@ -307,9 +307,9 @@ const retrieveUsage = function *(req) {
     spaces: []
   };
   return {
-    body: omit(doc,
-      '_id', '_rev', 'last_rated_usage_id', 'aggregated_usage_id',
-      'accumulated_usage_id')
+    body: omit(dbclient.undbify(doc),
+      ['last_rated_usage_id', 'aggregated_usage_id',
+      'accumulated_usage_id'])
   };
 };
 
@@ -333,9 +333,9 @@ routes.get(
     debug('Graphql query result %o', doc);
 
     return {
-      body: omit(doc.data,
-        '_id', '_rev', 'last_rated_usage_id', 'aggregated_usage_id',
-        'accumulated_usage_id')
+      body: omit(dbclient.undbify(doc.data),
+        ['last_rated_usage_id', 'aggregated_usage_id',
+        'accumulated_usage_id'])
     };
   }));
 

--- a/lib/metering/collector/src/index.js
+++ b/lib/metering/collector/src/index.js
@@ -20,7 +20,6 @@ const db = require('abacus-metering-db');
 const schemas = require('abacus-usage-schemas');
 
 const extend = _.extend;
-const omit = _.omit;
 const map = _.map;
 
 const tmap = yieldable(transform.map);
@@ -139,7 +138,7 @@ routes.get(
   '/v1/metering/resource/usage/t/:t/k/:provider', throttle(function *(req) {
     const id = dbclient.tkuri(req.params.provider, req.params.t);
     debug('Retrieving usage batch for id %s', id);
-    const doc = omit(yield submitdb.get(id), ['_id', '_rev']);
+    const doc = dbclient.undbify(yield submitdb.get(id));
     return {
       body: doc
     };
@@ -150,7 +149,7 @@ routes.get(
   '/v1/metering/usage/t/:t/k/:organization_id', throttle(function *(req) {
     const id = dbclient.tkuri(req.params.organization_id, req.params.t);
     debug('Retrieving usage for id %s', id);
-    const doc = omit(yield normdb.get(id), ['_id', '_rev']);
+    const doc = dbclient.undbify(yield normdb.get(id));
     return {
       body: doc
     };

--- a/lib/metering/meter/src/index.js
+++ b/lib/metering/meter/src/index.js
@@ -20,7 +20,6 @@ const db = require('abacus-metering-db');
 
 const map = _.map;
 const extend = _.extend;
-const omit = _.omit;
 const object = _.object;
 
 const brequest = yieldable(retry(breaker(batch(request))));
@@ -142,7 +141,7 @@ routes.get(
 
     // Retrieve and return the metered usage doc, and omit its _id and
     // _rev properties
-    const doc = omit(yield meterdb.get(id), ['_id', '_rev']);
+    const doc = dbclient.undbify(yield meterdb.get(id));
 
     // return the doc as response body
     return {


### PR DESCRIPTION
Running into 409 - document conflict errors when running integration tests.
Use undbifiy to omit database properties from the documents.

See tracker [#103216578]
