### PR TITLE
Add an express middleware to verify an OAuth token

### DIFF
--- a/lib/utils/cfoauth/src/index.js
+++ b/lib/utils/cfoauth/src/index.js
@@ -124,9 +124,34 @@ const validate = (token, secret, algorithm, cb) => {
   }
 };
 
+// Return an Express middleware that verifies an oauth bearer access token
+const validator = (secret, algorithm) => {
+  return (req, res, next) => {
+    // Check authoriation header field for a bearer access token
+    // then verfify the access token using jwt
+    if (req.headers.authorization &&
+      /^bearer /i.test(req.headers.authorization))
+      validate(req.headers.authorization.replace(/^bearer /i, ''),
+        secret, algorithm, (err, val) => {
+          if (err)
+            return res.status(401).header('WWW-Authenticate',
+              'Bearer realm="cf",' +
+              ' error="invalid_token",' +
+              ' error_description="' + err.message + '"').end();
+
+          // has a valid token, so proceed to process the request
+          return next();
+        });
+    else
+      return res.status(401).header('WWW-Authenticate',
+        'Bearer realm="cf"').end();
+  };
+};
+
 module.exports.tokenEndpoint = tokenEndpoint;
 module.exports.newToken = newToken;
 module.exports.decode = decode;
 module.exports.validate = validate;
+module.exports.validator = validator;
 module.exports.getScope = getScope;
 module.exports.getUserInfo = getUserInfo;

--- a/lib/utils/cfoauth/src/test/test.js
+++ b/lib/utils/cfoauth/src/test/test.js
@@ -20,11 +20,12 @@ process.env.TOKEN_ENDPOINT = 'localhost:35000';
 process.env.CLIENT_ID = 'clientid';
 process.env.CLIENT_SECRET = 'password';
 
-process.env.TOKEN_SECRET = '2DCQ@#R!Cyhj7nbs4t4f$Wbb34b';
-process.env.TOKEN_ALGORITHM = 'HS256';
+const tokenSecret = '2DCQ@#R!Cyhj7nbs4t4fWbb34b';
+const invalidTokenSecret = '3r3eF2D#v#tbrgTTbTg3rgbgf';
+const tokenAlgorithm = 'HS256'
 
-const secret = '2DCQ@#R!Cyhj7nbs4t4f$Wbb34b';
-const invalidSecret = '3r3eF2D#$v#$tbrgTTbTg3rgbgf';
+process.env.TOKEN_SECRET = tokenSecret;
+process.env.TOKEN_ALGORITHM = tokenAlgorithm;
 
 const invalidSignatureError = {
   name: 'JsonWebTokenError',
@@ -66,7 +67,7 @@ const encodedToken = 'eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJmYTFiMjlmZS03NmE' +
 
 const decodedToken = {
   header: {
-    alg: 'HS256'
+    alg: tokenAlgorithm
   },
   payload: {
     jti: 'fa1b29fe-76a9-4c2d-903e-dddd0563a9e3',
@@ -117,7 +118,7 @@ const encodedUserToken = 'eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiI1NTU1NTU1NS02' +
 
 const decodedUserToken = {
   header: {
-    alg: 'HS256'
+    alg: tokenAlgorithm
   },
   payload: {
     jti: '55555555-6666-7777-8888-999999999999',
@@ -341,12 +342,12 @@ describe('Decode token', () => {
 describe('Validate token', () => {
   it('Valid token - arguments', (done) => {
     // Sign known token using default algorithm (HS256)
-    const signed = jwt.sign(decodedToken.payload, secret, {
+    const signed = jwt.sign(decodedToken.payload, tokenSecret, {
       expiresInMinutes: 720
     });
 
     // Test the validation
-    oauth.validate(signed, secret, 'HS256',
+    oauth.validate(signed, tokenSecret, tokenAlgorithm,
       (err, val) => {
         expect(err).to.equal(null);
         expect(val).to.deep.equal(decodedToken.payload);
@@ -356,7 +357,7 @@ describe('Validate token', () => {
 
   it('Valid token - env property', (done) => {
     // Sign known token using default algorithm (HS256)
-    const signed = jwt.sign(decodedToken.payload, secret, {
+    const signed = jwt.sign(decodedToken.payload, tokenSecret, {
       expiresInMinutes: 720
     });
 
@@ -371,12 +372,12 @@ describe('Validate token', () => {
 
   it('Invalid signature', (done) => {
     // Sign known token using default algorithm (HS256) and invalid secret
-    const signed = jwt.sign(decodedToken.payload, invalidSecret, {
+    const signed = jwt.sign(decodedToken.payload, invalidTokenSecret, {
       expiresInMinutes: 720
     });
 
     // Test the validation
-    oauth.validate(signed, secret, 'HS256',
+    oauth.validate(signed, tokenSecret, tokenAlgorithm,
       (err, val) => {
         expect(err.name).to.equal(invalidSignatureError.name);
         expect(err.message).to.equal(invalidSignatureError.message);
@@ -387,13 +388,13 @@ describe('Validate token', () => {
 
   it('Signing algorithm not specified', (done) => {
     // Sign known token using default algorithm (HS256) and invalid secret
-    const signed = jwt.sign(decodedToken.payload, invalidSecret, {
+    const signed = jwt.sign(decodedToken.payload, invalidTokenSecret, {
       expiresInMinutes: 720
     });
 
     // Test the validation
     process.env.TOKEN_ALGORITHM = null;
-    oauth.validate(signed, secret, null,
+    oauth.validate(signed, tokenSecret, null,
       (err, val) => {
         expect(err.name).to.equal(invalidAlgorithmError.name);
         expect(err.message).to.equal(invalidAlgorithmError.message);
@@ -441,5 +442,73 @@ describe('Get scope', () => {
       'cloud_controller.read'
     ]);
     done();
+  });
+});
+
+describe('abacus-oauth', () => {
+  it('authenticate requests using validator middleware', (done) => {
+    // Create a test Express application
+    const app = express();
+
+    // Add oauth validator middleware
+    app.use(oauth.validator(tokenSecret, tokenAlgorithm));
+
+    // Get a protected resource
+    app.get('/protected/resource', (req, res) => {
+      res.send('okay');
+    });
+
+    // Listen on an ephemeral port
+    const server = app.listen(0);
+
+    let cbs = 0;
+    const cb = () => {
+      if (++cbs === 3) done();
+    };
+
+    // Request the protected resource without oauth token
+    request.get('http://localhost::port/protected/resource', {
+      port: server.address().port
+    }, (err, val) => {
+      expect(err).to.equal(undefined);
+      expect(val.statusCode).to.equal(401);
+      expect(val.headers['www-authenticate']).to.equal('Bearer realm="cf"');
+      cb();
+    });
+
+    // Request the protected resource using an oauth token with
+    // invalid signature
+    request.get('http://localhost::port/protected/resource', {
+      port: server.address().port,
+      auth: {
+        bearer: encodedUserToken
+      }
+    }, (err, val) => {
+      expect(err).to.equal(undefined);
+      expect(val.statusCode).to.equal(401);
+      expect(val.headers['www-authenticate']).to.equal('Bearer realm="cf",' +
+        ' error="invalid_token",' +
+        ' error_description="invalid signature"');
+      cb();
+    });
+
+    // Sign a known token using default algorithm (HS256)
+    const signed = jwt.sign(decodedToken.payload, tokenSecret, {
+      expiresInMinutes: 720
+    });
+
+    // Request the protected resource using a vaid oauth token
+    request.get('http://localhost::port/protected/resource', {
+      port: server.address().port,
+      auth: {
+        bearer: signed
+      }
+    }, (err, val) => {
+      expect(err).to.equal(undefined);
+      expect(val.statusCode).to.equal(200);
+      expect(val.headers['www-authenticate']).to.equal(undefined);
+      expect(val.body).to.equal('okay');
+      cb();
+    });
   });
 });


### PR DESCRIPTION
Clients need to make autheticated requests with an OAUTH 2.0 bearer access
token using the Authorization request header field.

Middleware authenticates or verifies bearer access token using JWT.

Middleware uses HTTP response code 401 and WWW-Authenticate response header
field with authentication or verification errors when responding to invalid
requests.

See tracker [#101701306] and github issue #35
