### PR TITLE
Fix router middleware to call next when a middleware uses 'next()'

### DIFF
--- a/lib/utils/router/src/index.js
+++ b/lib/utils/router/src/index.js
@@ -53,13 +53,12 @@ const callbackify = (m, trusted) => {
     try {
       mfunc.apply(undefined, params.concat([(err, value) => {
         if(err) error(err, 'generator error');
-        else if(value) {
+        else if(value)
           // Store the returned value in the response, it'll be sent
           // by one of our Express middleware later down the
           // middleware stack
           res.value = value;
-          next();
-        }
+        next();
       }]));
     }
     catch (exc) {

--- a/lib/utils/router/src/test/test.js
+++ b/lib/utils/router/src/test/test.js
@@ -29,6 +29,9 @@ describe('abacus-router', () => {
     // Create a router
     const routes = router();
 
+    // Add a simple router level middleware
+    routes.use((req, res, next) => next());
+
     // Add a few test routes
     routes.get('/ok/request', (req, res) => {
       // Return an OK response with a body


### PR DESCRIPTION
If a router level middleware passes the control to next middleware using
next() - without passing any arguments - then the router middleware does
not pass the control to the next middleware and lets the client request to
hang forever.

Ran into this issue when testing OAuth validator middleware with router.

See tracker [#101701306] and github issue #35
