### PR TITLE
Secure usage collector REST endpoints using OAuth bearer access token

### DIFF
--- a/lib/metering/collector/manifest.yml
+++ b/lib/metering/collector/manifest.yml
@@ -6,6 +6,9 @@ applications:
   memory: 512M
   disk_quota: 512M
   env:
+    SECURED: false
+    JWTKEY: undefined
+    JWTALGO: undefined
     COUCHDB: abacus-dbserver
     METER: abacus-usage-meter
     PROVISIONING: abacus-provisioning-stub

--- a/lib/metering/collector/package.json
+++ b/lib/metering/collector/package.json
@@ -36,6 +36,7 @@
     "babel-runtime": "^5.8.19",
     "abacus-batch": "file:../../utils/batch",
     "abacus-breaker": "file:../../utils/breaker",
+    "abacus-cfoauth": "file:../../utils/cfoauth",
     "abacus-dataflow": "file:../../utils/dataflow",
     "abacus-debug": "file:../../utils/debug",
     "abacus-request": "file:../../utils/request",

--- a/lib/metering/collector/src/index.js
+++ b/lib/metering/collector/src/index.js
@@ -16,6 +16,7 @@ const request = require('abacus-request');
 const urienv = require('abacus-urienv');
 const schemas = require('abacus-usage-schemas');
 const dataflow = require('abacus-dataflow');
+const oauth = require('abacus-cfoauth');
 
 const extend = _.extend;
 
@@ -25,6 +26,9 @@ const brequest = yieldable(retry(breaker(batch(request))));
 
 // Setup debug log
 const debug = require('abacus-debug')('abacus-usage-collector');
+
+// Secure the routes or not
+const secured = () => process.env.SECURED === 'true' ? true : false;
 
 // Resolve service URIs
 const uris = urienv({
@@ -62,6 +66,11 @@ const normalizeUsage = function *(udoc) {
 const collector = () => {
   const app = webapp();
 
+  // Secure metering and batch routes using an OAuth bearer access token
+  if (secured())
+    app.use(/^\/v1\/metering|^\/batch$/,
+      oauth.validator(process.env.JWTKEY, process.env.JWTALGO));
+
   const mapper = dataflow.mapper(normalizeUsage, {
     input: {
       type: 'collected_usage',
@@ -96,4 +105,3 @@ const runCLI = () => collector().listen();
 // Export our public functions
 module.exports = collector;
 module.exports.runCLI = runCLI;
-

--- a/lib/metering/collector/src/test/test.js
+++ b/lib/metering/collector/src/test/test.js
@@ -4,10 +4,14 @@
 
 const _ = require('underscore');
 const request = require('abacus-request');
+const batch = require('abacus-batch');
 const cluster = require('abacus-cluster');
+const oauth = require('abacus-cfoauth');
 
 const omit = _.omit;
 const extend = _.extend;
+
+const brequest = batch(request);
 
 // Configure test db URL prefix and splitter and provisioning service URLs
 process.env.COUCHDB = process.env.COUCHDB || 'test';
@@ -27,20 +31,20 @@ const reqmock = extend({}, request, {
 });
 require.cache[require.resolve('abacus-request')].exports = reqmock;
 
+// Mock the oauth module with a spy
+const oauthspy = spy((req, res, next) => next());
+const oauthmock = extend({}, oauth, {
+  validator: () => oauthspy
+});
+require.cache[require.resolve('abacus-cfoauth')].exports = oauthmock;
+
 const collector = require('..');
 
 describe('abacus-usage-collector', () => {
   it('stores and retrieves resource usage data', function(done) {
     this.timeout(60000);
 
-    // Create a test collector app
-    const app = collector();
-
-    // Listen on an ephemeral port
-    const server = app.listen(0);
-
-    // Post usage for a resource, expecting a 201 response
-    const batch = {
+    const measured = {
       usage: [{
         start: 1420243200000,
         end: 1420245000000,
@@ -61,21 +65,37 @@ describe('abacus-usage-collector', () => {
       }]
     };
 
-    request.post('http://localhost::p/v1/metering/collected/usage', {
-      p: server.address().port,
-      body: batch
-    }, (err, val) => {
-      expect(err).to.equal(undefined);
-      expect(val.statusCode).to.equal(201);
+    const verify = (secured, done) => {
+      process.env.SECURED = secured ? 'true' : 'false';
+      oauthspy.reset();
 
-      // Get usage, expecting what we posted
-      request.get(val.headers.location, {}, (err, val) => {
+      // Create a test collector app
+      const app = collector();
+
+      // Listen on an ephemeral port
+      const server = app.listen(0);
+
+      // Post usage for a resource, expecting a 201 response
+      request.post('http://localhost::p/v1/metering/collected/usage', {
+        p: server.address().port,
+        body: measured
+      }, (err, val) => {
         expect(err).to.equal(undefined);
-        expect(val.statusCode).to.equal(200);
-        expect(omit(val.body, 'id')).to.deep.equal(batch);
+        expect(val.statusCode).to.equal(201);
 
-        // Expect a call to the provisioning service
-        setTimeout(() => {
+        // Check oauth validator spy
+        expect(oauthspy.callCount).to.equal(secured ? 1 : 0);
+
+        // Get usage, expecting what we posted
+        brequest.get(val.headers.location, {}, (err, val) => {
+          expect(err).to.equal(undefined);
+          expect(val.statusCode).to.equal(200);
+          expect(omit(val.body, 'id')).to.deep.equal(measured);
+
+          // Check oauth validator spy
+          expect(oauthspy.callCount).to.equal(secured ? 3 : 0);
+
+          // Expect a call to the provisioning service
           expect(reqmock.batch_get.args[0][0][0][0]).to.equal(
             'http://localhost:9380/v1/provisioning/regions/:region/orgs/' +
             ':organization_id/spaces/:space_id/consumers/:consumer_id/' +
@@ -85,10 +105,13 @@ describe('abacus-usage-collector', () => {
           // Expect usage to be posted to the meter service too
           expect(reqmock.batch_post.args[0][0][0][0]).to.equal(
             'http://localhost:9081/v1/metering/normalized/usage');
+
           done();
-        }, 500);
+        });
       });
-    });
+    };
+
+    // Verify using an unsecured server and then verify using a secured server
+    verify(false, () => verify(true, done));
   });
 });
-


### PR DESCRIPTION
Define SECURED environment variable to enable authenticating incoming requests.

Define JWTKEY and JWTALGO environment variables to configure JWT-JWS based
bearer access token validation.

Add OAuth validator middleware to /v1/metering and /batch routes and update
unit tests.

See tracker [#101701306] and github issue #35.
