### PR TITLE
Secure usage meter REST endpoints using OAuth bearer access token

### DIFF
--- a/lib/metering/meter/manifest.yml
+++ b/lib/metering/meter/manifest.yml
@@ -6,6 +6,8 @@ applications:
   memory: 512M
   disk_quota: 512M
   env:
+    SECURED: false
+    JWTKEY: undefined
+    JWTALGO: undefined
     ACCUMULATOR: abacus-usage-accumulator
     COUCHDB: abacus-dbserver
-

--- a/lib/metering/meter/package.json
+++ b/lib/metering/meter/package.json
@@ -36,6 +36,7 @@
     "babel-runtime": "^5.8.19",
     "abacus-batch": "file:../../utils/batch",
     "abacus-breaker": "file:../../utils/breaker",
+    "abacus-cfoauth": "file:../../utils/cfoauth",
     "abacus-dataflow": "file:../../utils/dataflow",
     "abacus-dbclient": "file:../../utils/dbclient",
     "abacus-debug": "file:../../utils/debug",

--- a/lib/metering/meter/src/index.js
+++ b/lib/metering/meter/src/index.js
@@ -10,6 +10,7 @@ const seqid = require('abacus-seqid');
 const urienv = require('abacus-urienv');
 const config = require('abacus-resource-config');
 const dataflow = require('abacus-dataflow');
+const oauth = require('abacus-cfoauth');
 
 const map = _.map;
 const extend = _.extend;
@@ -17,6 +18,9 @@ const object = _.object;
 
 // Setup debug log
 const debug = require('abacus-debug')('abacus-usage-meter');
+
+// Secure the routes or not
+const secured = () => process.env.SECURED === 'true' ? true : false;
 
 // Resolve service URIs
 const uris = urienv({
@@ -72,6 +76,11 @@ const meterapp = () => {
 
   // Create the Webapp
   const app = webapp();
+
+  // Secure metering and batch routes using an OAuth bearer access token
+  if (secured())
+    app.use(/^\/v1\/metering|^\/batch$/,
+      oauth.validator(process.env.JWTKEY, process.env.JWTALGO));
 
   const mapper = dataflow.mapper(meterUsage, {
     input: {

--- a/lib/metering/meter/src/test/test.js
+++ b/lib/metering/meter/src/test/test.js
@@ -4,10 +4,14 @@
 
 const _ = require('underscore');
 const request = require('abacus-request');
+const batch = require('abacus-batch');
 const cluster = require('abacus-cluster');
+const oauth = require('abacus-cfoauth');
 
 const extend = _.extend;
 const omit = _.omit;
+
+const brequest = batch(request);
 
 // Configure test db URL prefix and splitter service URL
 process.env.COUCHDB = process.env.COUCHDB || 'test';
@@ -23,17 +27,18 @@ const reqmock = extend({}, request, {
 });
 require.cache[require.resolve('abacus-request')].exports = reqmock;
 
+// Mock the oauth module with a spy
+const oauthspy = spy((req, res, next) => next());
+const oauthmock = extend({}, oauth, {
+  validator: () => oauthspy
+});
+require.cache[require.resolve('abacus-cfoauth')].exports = oauthmock;
+
 const meterapp = require('..');
 
 describe('abacus-usage-meter', () => {
   it('meters usage docs', function(done) {
     this.timeout(60000);
-
-    // Create a test meter app
-    const app = meterapp();
-
-    // Listen on an ephemeral port
-    const server = app.listen(0);
 
     // Post usage for a resource, expecting the api to meter the usage, store
     // it in the database and return 201 as response with location URL as a
@@ -71,46 +76,65 @@ describe('abacus-usage-meter', () => {
       }]
     };
 
-    request.post('http://localhost::p/v1/metering/normalized/usage', {
-      p: server.address().port,
-      body: usage
-    }, (err, val) => {
-      expect(err).to.equal(undefined);
-      expect(val.statusCode).to.equal(201);
+    const verify = (secured, done) => {
+      process.env.SECURED = secured ? 'true' : 'false';
+      oauthspy.reset();
 
-      // Get metered usage, expecting what we posted
-      request.get(val.headers.location, {}, (err, val) => {
+      // Create a test meter app
+      const app = meterapp();
+
+      // Listen on an ephemeral port
+      const server = app.listen(0);
+
+      request.post('http://localhost::p/v1/metering/normalized/usage', {
+        p: server.address().port,
+        body: usage
+      }, (err, val) => {
         expect(err).to.equal(undefined);
-        expect(val.statusCode).to.equal(200);
+        expect(val.statusCode).to.equal(201);
 
-        expect(omit(val.body, 'id')).to.deep.equal(extend(omit(usage, 'id'), {
-          normalized_usage_id: '777',
-          metered_usage: [{
-            metric: 'storage',
-            quantity: 1
-          }, {
-            metric: 'thousand_light_api_calls',
-            quantity: 0.010
-          }, {
-            metric: 'heavy_api_calls',
-            quantity: 20
-          }, {
-            metric: 'memory',
-            quantity: {
-              consuming: 6,
-              since: 1420243200000
-            }
-          }]
-        }));
+        // Check oauth validator spy
+        expect(oauthspy.callCount).to.equal(secured ? 1 : 0);
 
-        // Expect usage to be posted to the accumulator service too
-        setTimeout(() => {
+        // Get metered usage, expecting what we posted
+        brequest.get(val.headers.location, {}, (err, val) => {
+          expect(err).to.equal(undefined);
+          expect(val.statusCode).to.equal(200);
+
+          // Check oauth validator spy
+          expect(oauthspy.callCount).to.equal(secured ? 3 : 0);
+
+          expect(omit(val.body, 'id')).to.deep.equal(extend(omit(usage, 'id'), {
+            normalized_usage_id: '777',
+            metered_usage: [{
+              metric: 'storage',
+              quantity: 1
+            }, {
+              metric: 'thousand_light_api_calls',
+              quantity: 0.010
+            }, {
+              metric: 'heavy_api_calls',
+              quantity: 20
+            }, {
+              metric: 'memory',
+              quantity: {
+                consuming: 6,
+                since: 1420243200000
+              }
+            }]
+          }));
+
+          // Expect usage to be posted to the accumulator service too
           expect(reqmock.batch_post.args[0][0][0][0])
             .to.equal('http://localhost:9100/v1/metering/metered/usage');
+
           done();
-        }, 500);
+        });
       });
-    });
+    };
+
+    // Verify using an unsecured server and then verify using a secured server
+    verify(false, () => verify(true, done));
   });
 });
 


### PR DESCRIPTION
Define SECURED environment variable to enable authenticating incoming requests.

Define JWTKEY and JWTALGO environment variables to configure JWT-JWS based
bearer access token validation.

Add OAuth validator middleware to /v1/metering and /batch routes and update
unit tests.

See tracker [#101701306] and github issue #35.
