### PR TITLE
Secure usage accumulator REST endpoints using OAuth bearer access token

### DIFF
--- a/lib/aggregation/accumulator/manifest.yml
+++ b/lib/aggregation/accumulator/manifest.yml
@@ -6,6 +6,8 @@ applications:
   memory: 512M
   disk_quota: 512M
   env:
+    SECURED: false
+    JWTKEY: undefined
+    JWTALGO: undefined
     AGGREGATOR: abacus-usage-aggregator
     COUCHDB: abacus-dbserver
-

--- a/lib/aggregation/accumulator/package.json
+++ b/lib/aggregation/accumulator/package.json
@@ -38,6 +38,7 @@
     "abacus-aggregation-db": "file:../db",
     "abacus-batch": "file:../../utils/batch",
     "abacus-breaker": "file:../../utils/breaker",
+    "abacus-cfoauth": "file:../../utils/cfoauth",
     "abacus-cluster": "file:../../utils/cluster",
     "abacus-dbclient": "file:../../utils/dbclient",
     "abacus-debug": "file:../../utils/debug",

--- a/lib/aggregation/accumulator/src/index.js
+++ b/lib/aggregation/accumulator/src/index.js
@@ -18,6 +18,7 @@ const seqid = require('abacus-seqid');
 const lockcb = require('abacus-lock');
 const db = require('abacus-aggregation-db');
 const config = require('abacus-resource-config');
+const oauth = require('abacus-cfoauth');
 
 const map = _.map;
 const last = _.last;
@@ -30,6 +31,9 @@ const brequest = yieldable(retry(breaker(batch(request))));
 const lock = yieldable(lockcb);
 
 /* eslint camelcase: 1 */
+
+// Secure the routes or not
+const secured = () => process.env.SECURED === 'true' ? true : false;
 
 // The scaling factor of each time window for creating the date string
 // [Second, Minute, Hour, Day, Month, Year, Forever]
@@ -330,6 +334,12 @@ const accumulator = () => {
 
   // Create the Webapp
   const app = webapp();
+
+  // Secure metering and batch routes using an OAuth bearer access token
+  if (secured())
+    app.use(/^\/v1\/metering|^\/batch$/,
+      oauth.validator(process.env.JWTKEY, process.env.JWTALGO));
+
   app.use(routes);
   app.use(router.batch(routes));
   return app;

--- a/lib/aggregation/accumulator/src/test/test.js
+++ b/lib/aggregation/accumulator/src/test/test.js
@@ -4,11 +4,15 @@
 
 const _ = require('underscore');
 const request = require('abacus-request');
+const batch = require('abacus-batch');
 const cluster = require('abacus-cluster');
 const transform = require('abacus-transform');
+const oauth = require('abacus-cfoauth');
 
 const extend = _.extend;
 const reduce = _.reduce;
+
+const brequest = batch(request);
 
 /* eslint handle-callback-err: 0 */
 
@@ -25,6 +29,13 @@ const reqmock = extend({}, request, {
   batch_post: spy((reqs, cb) => cb())
 });
 require.cache[require.resolve('abacus-request')].exports = reqmock;
+
+// Mock the oauth module with a spy
+const oauthspy = spy((req, res, next) => next());
+const oauthmock = extend({}, oauth, {
+  validator: () => oauthspy
+});
+require.cache[require.resolve('abacus-cfoauth')].exports = oauthmock;
 
 const accumulator = require('..');
 
@@ -489,5 +500,74 @@ describe('abacus-usage-accumulator', () => {
     // Run the above steps
     post(() => checkaggr(() => get(done)));
   });
-});
 
+  it('accumulates usage using unsecured and secured server', function(done) {
+    this.timeout(60000);
+
+    const metered = {
+      id: '222',
+      normalized_usage_id: '332',
+      collected_usage_id: '555',
+      metered_usage_id: '422',
+      resource_id: 'test-resource',
+      resource_instance_id: '0b39fa70-a65f-4183-bae8-385633ca5c87',
+      start: 1420243200000,
+      end: 1420245000000,
+      plan_id: 'basic',
+      region: 'us',
+      organization_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
+      space_id: 'aaeae239-f3f8-483c-9dd0-de5d41c38b6a',
+      consumer: {
+        type: 'EXTERNAL',
+        consumer_id: 'bbeae239-f3f8-483c-9dd0-de6781c38bab'
+      },
+      metered_usage: [{
+        metric: 'storage',
+        quantity: 1
+      }, {
+        metric: 'thousand_light_api_calls',
+        quantity: 0.01
+      }, {
+        metric: 'heavy_api_calls',
+        quantity: 20
+      }]
+    };
+
+    const verify = (secured, done) => {
+      process.env.SECURED = secured ? 'true' : 'false';
+      oauthspy.reset();
+
+      // Create a test accumulator app
+      const app = accumulator();
+
+      // Listen on an ephemeral port
+      const server = app.listen(0);
+
+      // Post usage for a resource, expecting a 201 response
+      request.post('http://localhost::p/v1/metering/metered/usage', {
+        p: server.address().port,
+        body: extend({}, metered, { end: 1420245000000 + (secured ? 2 : 1) })
+      }, (err, val) => {
+        expect(err).to.equal(undefined);
+        expect(val.statusCode).to.equal(201);
+
+        // Check oauth validator spy
+        expect(oauthspy.callCount).to.equal(secured ? 1 : 0);
+
+        // Get usage, expecting what we posted
+        brequest.get(val.headers.location, {}, (err, val) => {
+          expect(err).to.equal(undefined);
+          expect(val.statusCode).to.equal(200);
+
+          // Check oauth validator spy
+          expect(oauthspy.callCount).to.equal(secured ? 2 : 0);
+
+          done();
+        });
+      });
+    };
+
+    // Verify using an unsecured server and then verify using a secured server
+    verify(false, () => verify(true, done));
+  });
+});


### PR DESCRIPTION
Define SECURED environment variable to enable authenticating incoming requests.

Define JWTKEY and JWTALGO environment variables to configure JWT-JWS based
bearer access token validation.

Add OAuth validator middleware to /v1/metering and /batch routes and update
unit tests.

See tracker [#101701306] and github issue #35.
