### PR TITLE
Secure usage aggregator REST endpoints using OAuth bearer access token

### DIFF
--- a/lib/aggregation/aggregator/manifest.yml
+++ b/lib/aggregation/aggregator/manifest.yml
@@ -6,5 +6,7 @@ applications:
   memory: 512M
   disk_quota: 512M
   env:
+    SECURED: false
+    JWTKEY: undefined
+    JWTALGO: undefined
     COUCHDB: abacus-dbserver
-

--- a/lib/aggregation/aggregator/package.json
+++ b/lib/aggregation/aggregator/package.json
@@ -38,6 +38,7 @@
     "abacus-aggregation-db": "file:../db",
     "abacus-batch": "file:../../utils/batch",
     "abacus-breaker": "file:../../utils/breaker",
+    "abacus-cfoauth": "file:../../utils/cfoauth",
     "abacus-cluster": "file:../../utils/cluster",
     "abacus-dbclient": "file:../../utils/dbclient",
     "abacus-debug": "file:../../utils/debug",

--- a/lib/aggregation/aggregator/src/index.js
+++ b/lib/aggregation/aggregator/src/index.js
@@ -18,6 +18,7 @@ const seqid = require('abacus-seqid');
 const lockcb = require('abacus-lock');
 const db = require('abacus-aggregation-db');
 const config = require('abacus-resource-config');
+const oauth = require('abacus-cfoauth');
 
 const filter = _.filter;
 const map = _.map;
@@ -33,6 +34,9 @@ const lock = yieldable(lockcb);
 
 // Setup debug log
 const debug = require('abacus-debug')('abacus-usage-aggregator');
+
+// Secure the routes or not
+const secured = () => process.env.SECURED === 'true' ? true : false;
 
 // Resolve service URIs
 const uris = urienv({
@@ -423,6 +427,12 @@ const aggregator = () => {
 
   // Create the Webapp
   const app = webapp();
+
+  // Secure metering and batch routes using an OAuth bearer access token
+  if (secured())
+    app.use(/^\/v1\/metering|^\/batch$/,
+      oauth.validator(process.env.JWTKEY, process.env.JWTALGO));
+
   app.use(routes);
   app.use(router.batch(routes));
   return app;
@@ -436,4 +446,3 @@ module.exports = aggregator;
 module.exports.newOrg = newOrg;
 module.exports.reviveOrg = reviveOrg;
 module.exports.runCLI = runCLI;
-

--- a/lib/aggregation/aggregator/src/test/test.js
+++ b/lib/aggregation/aggregator/src/test/test.js
@@ -5,12 +5,16 @@
 const _ = require('underscore');
 
 const request = require('abacus-request');
+const batch = require('abacus-batch');
 const cluster = require('abacus-cluster');
 const transform = require('abacus-transform');
+const oauth = require('abacus-cfoauth');
 
 const extend = _.extend;
 const omit = _.omit;
 const reduce = _.reduce;
+
+const brequest = batch(request);
 
 // Configure test db URL prefix
 process.env.COUCHDB = process.env.COUCHDB || 'test';
@@ -26,6 +30,13 @@ const reqmock = extend({}, request, {
   batch_post: spy((reqs, cb) => cb())
 });
 require.cache[require.resolve('abacus-request')].exports = reqmock;
+
+// Mock the oauth module with a spy
+const oauthspy = spy((req, res, next) => next());
+const oauthmock = extend({}, oauth, {
+  validator: () => oauthspy
+});
+require.cache[require.resolve('abacus-cfoauth')].exports = oauthmock;
 
 const aggregator = require('..');
 
@@ -204,12 +215,6 @@ describe('abacus-usage-aggregator', () => {
 
   it('aggregates usage for an organization', function(done) {
     this.timeout(60000);
-
-    // Create a test aggregator app
-    const app = aggregator();
-
-    // Listen on an ephemeral port
-    const server = app.listen(0);
 
     // Define a sequence of accumulated usage for several resource instances
     const usage = [
@@ -665,28 +670,6 @@ describe('abacus-usage-aggregator', () => {
             }]
         }]
       }];
-
-    // Post accumulated usage to the aggregator
-    let locations = {};
-    const post = (done) => {
-
-      // Post each usage doc
-      transform.map(usage, (u, i, l, cb) => request.post(
-        'http://localhost::p/v1/metering/accumulated/usage', {
-          p: server.address().port,
-          body: u
-        }, (err, val) => {
-          expect(err).to.equal(undefined);
-
-          // Expect a 201 with the location of the aggregated usage
-          expect(val.statusCode).to.equal(201);
-          expect(val.headers.location).to.not.equal(undefined);
-
-          // Record the location returned for each usage doc
-          locations[u.id] = val.headers.location;
-          cb();
-        }), done);
-    };
 
     // Define the sequence of aggregated usage we're expecting for an org
     const aggregated = [{
@@ -1799,9 +1782,51 @@ describe('abacus-usage-aggregator', () => {
         }]
     }];
 
-    // Check posts to the rating service
-    const checkrating = (done) => {
-      setTimeout(() => {
+    const verify = (secured, done) => {
+      process.env.SECURED = secured ? 'true' : 'false';
+      oauthspy.reset();
+      reqmock.batch_post.reset();
+
+      // Create a test aggregator app
+      const app = aggregator();
+
+      // Listen on an ephemeral port
+      const server = app.listen(0);
+
+      // Post accumulated usage to the aggregator
+      let locations = {};
+      const post = (done) => {
+
+        // Post each usage doc
+        transform.map(usage, (u, i, l, cb) => request.post(
+          'http://localhost::p/v1/metering/accumulated/usage', {
+            p: server.address().port,
+            body: extend({}, u, {
+              organization_id:
+                ['a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
+                  secured ? 1 : 0].join('-')
+            })
+          }, (err, val) => {
+            expect(err).to.equal(undefined);
+
+            // Expect a 201 with the location of the aggregated usage
+            expect(val.statusCode).to.equal(201);
+            expect(val.headers.location).to.not.equal(undefined);
+
+            // Record the location returned for each usage doc
+            locations[u.id] = val.headers.location;
+            cb();
+          }), () => {
+            // Check oauth validator spy
+            expect(oauthspy.callCount).to.equal(secured ? 4 : 0);
+
+            done();
+          });
+      };
+
+
+      // Check posts to the rating service
+      const checkrating = (done) => {
         // Expect usage docs to have been posted to the rating service
         expect(reduce(reqmock.batch_post.args, (a, b) => {
           return a + reduce(b[0], (a, b) => {
@@ -1810,41 +1835,50 @@ describe('abacus-usage-aggregator', () => {
           }, 0);
         }, 0)).to.equal(4);
         done();
-      }, 500);
+      };
+
+      // Get the aggregated usage history
+      const get = (done) => {
+        let check;
+
+        // Get each version of the aggregated usage
+        transform.map(usage, (u, i, l, cb) =>
+          brequest.get(locations[u.id], {}, (err, val) => {
+            expect(err).to.equal(undefined);
+            expect(val.statusCode).to.equal(200);
+
+            // Expect our test accumulated usage ids
+            expect(val.body.accumulated_usage_id).to.equal(u.id);
+
+            // Expect the test final aggregated usage
+            if (i === 3) {
+              expect(omit(val.body, 'id', 'accumulated_usage_id'))
+                .to.deep.equal(extend({},
+                  omit(aggregated[3], 'accumulated_usage_id'), {
+                    organization_id:
+                      ['a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
+                        secured ? 1 : 0].join('-')
+                  }));
+              check = true;
+            }
+
+            cb();
+          }), () => {
+            // Expect to have seen the final test aggregated usage
+            expect(check).to.equal(true);
+
+            // Check oauth validator spy
+            expect(oauthspy.callCount).to.equal(secured ? 5 : 0);
+
+            done();
+          });
+      };
+
+      // Run the above steps
+      post(() => checkrating(() => get(done)));
     };
 
-    // Get the aggregated usage history
-    const get = (done) => {
-      let check;
-
-      // Get each version of the aggregated usage
-      transform.map(usage, (u, i, l, cb) =>
-        request.get(locations[u.id], {}, (err, val) => {
-          expect(err).to.equal(undefined);
-          expect(val.statusCode).to.equal(200);
-
-          // Expect our test accumulated usage ids
-          expect(val.body.accumulated_usage_id).to.equal(u.id);
-
-          // Expect the test final aggregated usage
-          try {
-            expect(omit(val.body, 'id', 'accumulated_usage_id'))
-                .to.deep.equal(omit(aggregated[3], 'accumulated_usage_id'));
-            check = true;
-            cb();
-          }
-          catch(e) {
-            cb();
-          }
-        }), () => {
-          // Expect to have seen the final test aggregated usage
-          expect(check).to.equal(true);
-          done();
-        });
-    };
-
-    // Run the above steps
-    post(() => checkrating(() => get(done)));
+    // Verify using an unsecured server and then verify using a secured server
+    verify(false, () => verify(true, done));
   });
 });
-


### PR DESCRIPTION
Define SECURED environment variable to enable authenticating incoming requests.

Define JWTKEY and JWTALGO environment variables to configure JWT-JWS based
bearer access token validation.

Add OAuth validator middleware to /v1/metering and /batch routes and update
unit tests.

When checking aggregated usage logs, verify usage content only for the
last aggregated usage. Fixes random unit test failure with error message
'Uncaught AssertionError: expected undefined to equal true'.

See tracker [#101701306] and github issue #35.
