### PR TITLE
Secure usage rating service REST endpoints using OAuth bearer token

### DIFF
--- a/lib/aggregation/rate/manifest.yml
+++ b/lib/aggregation/rate/manifest.yml
@@ -6,4 +6,7 @@ applications:
   memory: 512M
   disk_quota: 512M
   env:
+    SECURED: false
+    JWTKEY: undefined
+    JWTALGO: undefined
     COUCHDB: abacus-dbserver

--- a/lib/aggregation/rate/package.json
+++ b/lib/aggregation/rate/package.json
@@ -36,6 +36,7 @@
     "abacus-aggregation-db": "file:../../aggregation/db",
     "abacus-batch": "file:../../utils/batch",
     "abacus-breaker": "file:../../utils/breaker",
+    "abacus-cfoauth": "file:../../utils/cfoauth",
     "abacus-cluster": "file:../../utils/cluster",
     "abacus-dbclient": "file:../../utils/dbclient",
     "abacus-debug": "file:../../utils/debug",

--- a/lib/aggregation/rate/src/index.js
+++ b/lib/aggregation/rate/src/index.js
@@ -19,6 +19,7 @@ const lockcb = require('abacus-lock');
 const config = require('abacus-resource-config');
 const prices = require('abacus-price-config');
 const db = require('abacus-aggregation-db');
+const oauth = require('abacus-cfoauth');
 
 const filter = _.filter;
 const map = _.map;
@@ -32,6 +33,9 @@ const lock = yieldable(lockcb);
 
 // Setup debug log
 const debug = require('abacus-debug')('abacus-usage-rate');
+
+// Secure the routes or not
+const secured = () => process.env.SECURED === 'true' ? true : false;
 
 // Resolve service URIs
 const uris = urienv({
@@ -315,6 +319,12 @@ const rateapp = () => {
 
   // Create the Webapp
   const app = webapp();
+
+  // Secure rating and batch routes using an OAuth bearer access token
+  if (secured())
+    app.use(/^\/v1\/rating|^\/batch$/,
+      oauth.validator(process.env.JWTKEY, process.env.JWTALGO));
+
   app.use(routes);
   app.use(router.batch(routes));
   return app;
@@ -327,4 +337,3 @@ const runCLI = () => rateapp().listen();
 module.exports = rateapp;
 module.exports.rate = rate;
 module.exports.runCLI = runCLI;
-

--- a/lib/aggregation/rate/src/test/test.js
+++ b/lib/aggregation/rate/src/test/test.js
@@ -3,16 +3,21 @@
 // Usage rating service
 
 const _ = require('underscore');
-const cluster = require('abacus-cluster');
-const omit = _.omit;
-const map = _.map;
+
 const request = require('abacus-request');
+const batch = require('abacus-batch');
 const transform = require('abacus-transform');
+const cluster = require('abacus-cluster');
+const oauth = require('abacus-cfoauth');
+
+const map = _.map;
+const extend = _.extend;
+const omit = _.omit;
+
+const brequest = batch(request);
 
 // Configure test db URL
 process.env.COUCHDB = process.env.COUCHDB || 'test';
-
-const extend = _.extend;
 
 // Mock the cluster module
 require.cache[require.resolve('abacus-cluster')].exports =
@@ -29,18 +34,19 @@ const reqmock = extend({}, request, {
 });
 require.cache[require.resolve('abacus-request')].exports = reqmock;
 
+// Mock the oauth module with a spy
+const oauthspy = spy((req, res, next) => next());
+const oauthmock = extend({}, oauth, {
+  validator: () => oauthspy
+});
+require.cache[require.resolve('abacus-cfoauth')].exports = oauthmock;
+
 const rateapp = require('..');
 
 describe('abacus-usage-rate', () => {
   describe('usage rating', () => {
     it('rates usage', function(done) {
       this.timeout(60000);
-
-      // Create a test rate app
-      const app = rateapp();
-
-      // Listen on an ephemeral port
-      const server = app.listen(0);
 
       // Define aggregated usage to be rated
       const usage = [{
@@ -558,28 +564,6 @@ describe('abacus-usage-rate', () => {
         }]
       }];
 
-      // Post aggregated usage to the rating service
-      let locations = {};
-      const post = (done) => {
-
-        // Post each usage doc
-        transform.reduce(usage, (a, u, i, l, cb) =>
-          request.post('http://localhost::p/v1/rating/usage', {
-            p: server.address().port,
-            body: u
-          }, (err, val) => {
-            expect(err).to.equal(undefined);
-
-            // Expect a 201 to be return along with the location in the header
-            expect(val.statusCode).to.equal(201);
-            expect(val.headers.location).to.not.equal(undefined);
-
-            // Record the header location for retrieval later in the test
-            locations[u.id] = val.headers.location;
-            cb();
-          }), undefined, done);
-      };
-
       // Define the expected rated usage
       const rated = [{
         organization_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
@@ -844,28 +828,74 @@ describe('abacus-usage-rate', () => {
         }]
       }];
 
-      // Get the rated usage
-      const get = (done) => {
-        let cbs = 0;
-        const cb = () => {
-          if(++cbs === usage.length) done();
+      const verify = (secured, done) => {
+        process.env.SECURED = secured ? 'true' : 'false';
+        oauthspy.reset();
+
+        // Create a test rate app
+        const app = rateapp();
+
+        // Listen on an ephemeral port
+        const server = app.listen(0);
+
+        // Post aggregated usage to the rating service
+        let locations = {};
+        const post = (done) => {
+
+          // Post each usage doc
+          transform.reduce(usage, (a, u, i, l, cb) =>
+            request.post('http://localhost::p/v1/rating/usage', {
+              p: server.address().port,
+              body: u
+            }, (err, val) => {
+              expect(err).to.equal(undefined);
+
+              // Expect a 201 to be return along with the location in the header
+              expect(val.statusCode).to.equal(201);
+              expect(val.headers.location).to.not.equal(undefined);
+
+              // Record the header location for retrieval later in the test
+              locations[u.id] = val.headers.location;
+              cb();
+            }), undefined, () => {
+              // Check oauth validator spy$
+              expect(oauthspy.callCount).to.equal(secured ? usage.length : 0);
+
+              done();
+            });
         };
 
-        // Call a Get on the app
-        map(usage, (u) => request.get(locations[u.id], {}, (err, val) => {
-          expect(err).to.equal(undefined);
-          expect(val.statusCode).to.equal(200);
+        // Get the rated usage
+        const get = (done) => {
+          let cbs = 0;
+          const cb = () => {
+            if(++cbs === usage.length) {
+              // Check oauth validator spy
+              expect(oauthspy.callCount).to.equal(secured ?
+                usage.length + 1 : 0);
 
-          // Expect our test aggregated values
-          if(val.body.end === 1436054400000)
-            expect(omit(val.body, 'id')).to.deep.equal(rated[0]);
-          cb();
-        }));
+              done();
+            }
+          };
+
+          // Call a Get on the app
+          map(usage, (u) => brequest.get(locations[u.id], {}, (err, val) => {
+            expect(err).to.equal(undefined);
+            expect(val.statusCode).to.equal(200);
+
+            // Expect our test aggregated values
+            if(val.body.end === 1436054400000)
+              expect(omit(val.body, 'id')).to.deep.equal(rated[0]);
+            cb();
+          }));
+        };
+
+        // Run the above steps
+        post(() => get(done));
       };
 
-      // Run the above steps
-      post(() => get(done));
+      // Verify using an unsecured server and then verify using a secured server
+      verify(false, () => verify(true, done));
     });
   });
 });
-


### PR DESCRIPTION
Define SECURED environment variable to enable authenticating incoming requests.

Define JWTKEY and JWTALGO environment variables to configure JWT-JWS based
bearer access token validation.

Add OAuth validator middleware to /v1/rating and /batch routes and update
unit tests.

See tracker [#101701306] and github issue #35.
