### PR TITLE
Fix a random unit test failure at usage aggregator

### DIFF
--- a/lib/aggregation/aggregator/src/test/test.js
+++ b/lib/aggregation/aggregator/src/test/test.js
@@ -1798,7 +1798,7 @@ describe('abacus-usage-aggregator', () => {
       const post = (done) => {
 
         // Post each usage doc
-        transform.map(usage, (u, i, l, cb) => request.post(
+        transform.reduce(usage, (a, u, i, l, cb) => request.post(
           'http://localhost::p/v1/metering/accumulated/usage', {
             p: server.address().port,
             body: extend({}, u, {
@@ -1816,7 +1816,7 @@ describe('abacus-usage-aggregator', () => {
             // Record the location returned for each usage doc
             locations[u.id] = val.headers.location;
             cb();
-          }), () => {
+          }), undefined, () => {
             // Check oauth validator spy
             expect(oauthspy.callCount).to.equal(secured ? 4 : 0);
 
@@ -1850,7 +1850,7 @@ describe('abacus-usage-aggregator', () => {
             // Expect our test accumulated usage ids
             expect(val.body.accumulated_usage_id).to.equal(u.id);
 
-            // Expect the test final aggregated usage
+            // Expect our final test aggregated usage
             if (i === 3) {
               expect(omit(val.body, 'id', 'accumulated_usage_id'))
                 .to.deep.equal(extend({},


### PR DESCRIPTION
Accumulated usage are received by usage aggregator in a random order.
To order the accumulated usage submission, use transform.reduce.

Fixes github issue #64.
