### PR TITLE
Secure usage reporting service REST endpoints using OAuth bearer token

### DIFF
--- a/lib/aggregation/reporting/manifest.yml
+++ b/lib/aggregation/reporting/manifest.yml
@@ -6,6 +6,8 @@ applications:
   memory: 512M
   disk_quota: 512M
   env:
+    SECURED: false
+    JWTKEY: undefined
+    JWTALGO: undefined
     COUCHDB: abacus-dbserver
     ACCOUNT: abacus-account-stub
-

--- a/lib/aggregation/reporting/package.json
+++ b/lib/aggregation/reporting/package.json
@@ -37,6 +37,7 @@
     "abacus-aggregation-db": "file:../db",
     "abacus-batch": "file:../../utils/batch",
     "abacus-breaker": "file:../../utils/breaker",
+    "abacus-cfoauth": "file:../../utils/cfoauth",
     "abacus-cluster": "file:../../utils/cluster",
     "abacus-dbclient": "file:../../utils/dbclient",
     "abacus-debug": "file:../../utils/debug",

--- a/lib/aggregation/reporting/src/index.js
+++ b/lib/aggregation/reporting/src/index.js
@@ -18,6 +18,7 @@ const db = require('abacus-aggregation-db');
 const schemas = require('abacus-usage-schemas');
 const config = require('abacus-resource-config');
 const schema = require('abacus-schema');
+const oauth = require('abacus-cfoauth');
 
 const omit = _.omit;
 const map = _.map;
@@ -41,6 +42,9 @@ const GraphQLList = schema.graphql.GraphQLList;
 
 // Setup debug log
 const debug = require('abacus-debug')('abacus-usage-reporting');
+
+// Secure the routes or not
+const secured = () => process.env.SECURED === 'true' ? true : false;
 
 // Resolve service URIs
 const uris = urienv({
@@ -342,6 +346,13 @@ routes.get(
 // Create a reporting app
 const reporting = () => {
   const app = webapp();
+
+  // Secure organizations, metering and batch routes
+  // using an OAuth bearer access token
+  if (secured())
+    app.use(/^\/v1\/organizations|^\/v1\/metering|^\/batch$/,
+      oauth.validator(process.env.JWTKEY, process.env.JWTALGO));
+
   app.use(routes);
   app.use(router.batch(routes));
   return app;
@@ -353,4 +364,3 @@ const runCLI = () => reporting().listen();
 // Export our public functions
 module.exports = reporting;
 module.exports.runCLI = runCLI;
-

--- a/lib/aggregation/reporting/src/test/test.js
+++ b/lib/aggregation/reporting/src/test/test.js
@@ -4,10 +4,14 @@
 
 const _ = require('underscore');
 const request = require('abacus-request');
+const batch = require('abacus-batch');
 const db = require('abacus-aggregation-db');
 const cluster = require('abacus-cluster');
+const oauth = require('abacus-cfoauth');
 
 const extend = _.extend;
+
+const brequest = batch(request);
 
 /* eslint quotes: 1 */
 
@@ -17,6 +21,13 @@ process.env.COUCHDB = process.env.COUCHDB || 'test';
 // Mock the cluster module
 require.cache[require.resolve('abacus-cluster')].exports =
   extend((app) => app, cluster);
+
+// Mock the oauth module with a spy
+const oauthspy = spy((req, res, next) => next());
+const oauthmock = extend({}, oauth, {
+  validator: () => oauthspy
+});
+require.cache[require.resolve('abacus-cfoauth')].exports = oauthmock;
 
 const report = require('..');
 
@@ -299,12 +310,6 @@ describe('abacus-usage-report', () => {
 
   it('retrieves rated usage for an organization', function(done) {
     this.timeout(60000);
-
-    // Create a test report app
-    const app = report();
-
-    // Listen on an ephemeral port
-    const server = app.listen(0);
 
     // Define the expected usage report
     const expected = {
@@ -665,30 +670,42 @@ describe('abacus-usage-report', () => {
       }]
     };
 
-    // Get the rated usage
-    request.get(
-      'http://localhost::p/v1/organizations/:organization_id/usage/:time', {
-        p: server.address().port,
-        organization_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
-        time: 1420502400000
-      }, (err, val) => {
-        expect(err).to.equal(undefined);
+    const verify = (secured, done) => {
+      process.env.SECURED = secured ? 'true' : 'false';
+      oauthspy.reset();
 
-        // Expect our test rated usage
-        expect(val.statusCode).to.equal(200);
-        expect(val.body).to.deep.equal(expected);
-        done();
-      });
+      // Create a test report app
+      const app = report();
+
+      // Listen on an ephemeral port
+      const server = app.listen(0);
+
+      // Get the rated usage
+      request.get(
+        'http://localhost::p/v1/organizations/:organization_id/usage/:time', {
+          p: server.address().port,
+          organization_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
+          time: 1420502400000
+        }, (err, val) => {
+          expect(err).to.equal(undefined);
+
+          // Expect our test rated usage
+          expect(val.statusCode).to.equal(200);
+          expect(val.body).to.deep.equal(expected);
+
+          // Check oauth validator spy
+          expect(oauthspy.callCount).to.equal(secured ? 1 : 0);
+
+          done();
+        });
+    };
+
+    // Verify using an unsecured server and then verify using a secured server
+    verify(false, () => verify(true, done));
   });
 
   it('queries rated usage for an organization', function(done) {
     this.timeout(60000);
-
-    // Create a test report app
-    const app = report();
-
-    // Listen on an ephemeral port
-    const server = app.listen(0);
 
     // Define a GraphQL query and the corresponding expected result
     const query = '{ organization(organization_id: ' +
@@ -723,29 +740,41 @@ describe('abacus-usage-report', () => {
       }
     };
 
-    // Get the rated usage
-    request.get(
-      'http://localhost::p/v1/metering/aggregated/usage/graph/:query', {
-        p: server.address().port,
-        query: query
-      }, (err, val) => {
-        expect(err).to.equal(undefined);
+    const verify = (secured, done) => {
+      process.env.SECURED = secured ? 'true' : 'false';
+      oauthspy.reset();
 
-        // Expect our test rated usage
-        expect(val.statusCode).to.equal(200);
-        expect(val.body).to.deep.equal(expected);
-        done();
-      });
+      // Create a test report app
+      const app = report();
+
+      // Listen on an ephemeral port
+      const server = app.listen(0);
+
+      // Get the rated usage
+      request.get(
+        'http://localhost::p/v1/metering/aggregated/usage/graph/:query', {
+          p: server.address().port,
+          query: query
+        }, (err, val) => {
+          expect(err).to.equal(undefined);
+
+          // Expect our test rated usage
+          expect(val.statusCode).to.equal(200);
+          expect(val.body).to.deep.equal(expected);
+
+          // Check oauth validator spy
+          expect(oauthspy.callCount).to.equal(secured ? 1 : 0);
+
+          done();
+        });
+    };
+
+    // Verify using an unsecured server and then verify using a secured server
+    verify(false, () => verify(true, done));
   });
 
   it('queries rated usage for a list of organizations', function(done) {
     this.timeout(60000);
-
-    // Create a test report app
-    const app = report();
-
-    // Listen on an ephemeral port
-    const server = app.listen(0);
 
     // Define the GraphQL query and the corresponding expected result
     const query = '{ organizations(organization_ids: ' +
@@ -779,19 +808,36 @@ describe('abacus-usage-report', () => {
       }]
     };
 
-    // Get the rated usage
-    request.get(
-      'http://localhost::p/v1/metering/aggregated/usage/graph/:query', {
-        p: server.address().port,
-        query: query
-      }, (err, val) => {
-        expect(err).to.equal(undefined);
+    const verify = (secured, done) => {
+      process.env.SECURED = secured ? 'true' : 'false';
+      oauthspy.reset();
 
-        // Expect our test rated usage
-        expect(val.statusCode).to.equal(200);
-        expect(val.body).to.deep.equal(expected);
-        done();
-      });
+      // Create a test report app
+      const app = report();
+
+      // Listen on an ephemeral port
+      const server = app.listen(0);
+
+      // Get the rated usage
+      brequest.get(
+        'http://localhost::p/v1/metering/aggregated/usage/graph/:query', {
+          p: server.address().port,
+          query: query
+        }, (err, val) => {
+          expect(err).to.equal(undefined);
+
+          // Expect our test rated usage
+          expect(val.statusCode).to.equal(200);
+          expect(val.body).to.deep.equal(expected);
+
+          // Check oauth validator spy
+          expect(oauthspy.callCount).to.equal(secured ? 1 : 0);
+
+          done();
+        });
+    };
+
+    // Verify using an unsecured server and then verify using a secured server
+    verify(false, () => verify(true, done));
   });
 });
-


### PR DESCRIPTION
Define SECURED environment variable to enable authenticating incoming requests.

Define JWTKEY and JWTALGO environment variables to configure JWT-JWS based
bearer access token validation.

Add OAuth validator middleware to /v1/organizations /v1/metering and /batch
routes and update unit tests.

See tracker [#101701306] and github issue #35.
