### PR TITLE
Forward authorization header field across the pipeline

### DIFF
--- a/lib/aggregation/accumulator/src/index.js
+++ b/lib/aggregation/accumulator/src/index.js
@@ -24,6 +24,7 @@ const map = _.map;
 const last = _.last;
 const extend = _.extend;
 const omit = _.omit;
+const pick = _.pick;
 const filter = _.filter;
 
 const brequest = yieldable(retry(breaker(batch(request))));
@@ -240,7 +241,7 @@ const updateAccumulatedUsage =
   })));
 
 // Accumulate the given usage
-const accumulateUsage = function *(u) {
+const accumulateUsage = function *(u, opt) {
   // Compute the usage log id and accumulated usage id
   const k = [u.organization_id, u.resource_instance_id, u.plan_id].join('/');
   const ulogid = dbclient.kturi(k, [u.end, u.start, u.end].join('/'));
@@ -263,11 +264,16 @@ const accumulateUsage = function *(u) {
     id: alogid,
     processed_usage_id: ulogid
   });
+
+  // Forward authorization header field to usage aggregator
+  const o = opt && opt.authorization ?
+    { headers: pick(opt, 'authorization') } : {};
+
   yieldable.functioncb(brequest.post)(
     (yield aggreguri(alogdoc.organization_id, alogdoc.start)) +
-      '/v1/metering/accumulated/usage', {
+      '/v1/metering/accumulated/usage', extend(o, {
         body: alogdoc
-      }, (err, res) => {
+      }), (err, res) => {
         if(err)
           debug('Failed to post %s to aggregator service, %o', alogid, err);
       });
@@ -287,7 +293,7 @@ routes.post('/v1/metering/metered/usage', throttle(function *(req) {
 
   // Accumulate usage
   debug('Accumulating usage %o', u);
-  const id = yield accumulateUsage(u);
+  const id = yield accumulateUsage(u, pick(req.headers, 'authorization'));
 
   // Return the location of the new accumulated usage
   return {

--- a/lib/aggregation/aggregator/src/index.js
+++ b/lib/aggregation/aggregator/src/index.js
@@ -25,6 +25,7 @@ const map = _.map;
 const last = _.last;
 const extend = _.extend;
 const omit = _.omit;
+const pick = _.pick;
 
 const brequest = yieldable(retry(breaker(batch(request))));
 
@@ -341,7 +342,7 @@ const updateAggregatedUsage =
   })));
 
 // Aggregate the given accumulated usage
-const aggregateUsage = function *(u) {
+const aggregateUsage = function *(u, opt) {
   // Compute the usage log id and aggregated usage id
   const aid = dbclient.kturi(u.organization_id, 0);
   const alogid = dbclient.kturi(u.organization_id,
@@ -357,13 +358,16 @@ const aggregateUsage = function *(u) {
     accumulated_usage_id: u.id
   });
 
+  // Forward authorization header field to rating service
+  const o = opt && opt.authorization ?
+    { headers: pick(opt, 'authorization') } : {};
+
   // Post the new aggregated usage to the rating service
   yieldable.functioncb(brequest.post)(
     (yield ratinguri(alogdoc.organization_id, alogdoc.start)) +
-      '/v1/rating/usage',
-    {
+    '/v1/rating/usage', extend(o, {
       body: alogdoc
-    }, (err, res) => {
+    }), (err, res) => {
       if(err)
         debug('Failed to post %s to rating service, %o', alogid, err);
     });
@@ -381,7 +385,7 @@ routes.post('/v1/metering/accumulated/usage', throttle(function *(req) {
 
   // Aggregate usage
   debug('Aggregating usage %o', u);
-  const id = yield aggregateUsage(u);
+  const id = yield aggregateUsage(u, pick(req.headers, 'authorization'));
 
   // Return the location of the new aggregated usage
   return {

--- a/lib/aggregation/rate/src/index.js
+++ b/lib/aggregation/rate/src/index.js
@@ -26,6 +26,7 @@ const map = _.map;
 const last = _.last;
 const extend = _.extend;
 const omit = _.omit;
+const pick = _.pick;
 
 const brequest = yieldable(retry(breaker(batch(request))));
 
@@ -63,11 +64,15 @@ const day = (t) => {
 };
 
 // Return the pricing country configured for an organization's account
-const pricingCountry = function *(oid) {
+const pricingCountry = function *(oid, opt) {
+  // Forward authorization header field to account
+  const o = opt && opt.authroization ?
+    { headers: pick(opt, 'authorization') } : {};
+
   const account = yield brequest.get(
-    uris.account + '/v1/orgs/:org_id/account', {
+    uris.account + '/v1/orgs/:org_id/account', extend(o, {
       org_id: oid
-    });
+    }));
 
   // Default to USA
   return !account.body || !account.body.pricing_country ?
@@ -214,7 +219,8 @@ const updateRatedUsage =
       };
 
       // Retrieve the pricing country configured for the org's account
-      const pc = yield pricingCountry(calls[0][0].u.organization_id);
+      const pc = yield pricingCountry(calls[0][0].u.organization_id,
+        calls[0][0].opt);
 
       // Rate the usage docs
       const rres = map(calls, (call) => {
@@ -237,7 +243,7 @@ const updateRatedUsage =
   })));
 
 // Rate the given aggregated usage
-const rateUsage = function *(u) {
+const rateUsage = function *(u, opt) {
   // Compute the rated usage id and the rated usage log id
   const rid = dbclient.kturi(u.organization_id, day(u.end));
   const rlogid = dbclient.kturi(u.organization_id, [
@@ -245,7 +251,7 @@ const rateUsage = function *(u) {
 
   // Rate the usage
   const newr = yield updateRatedUsage({
-    u: u, rid: rid, rlogid: rlogid, uid: u.id });
+    u: u, rid: rid, rlogid: rlogid, uid: u.id, opt: opt });
 
   // Log the rated usage
   const rlogdoc = extend(dbclient.undbify(newr), {
@@ -271,7 +277,7 @@ routes.post('/v1/rating/usage', throttle(function *(req) {
   const u = req.body;
 
   // Rate the usage
-  const id = yield rateUsage(u);
+  const id = yield rateUsage(u, pick(req.headers, 'authorization'));
 
   return {
     statusCode: 201,

--- a/lib/aggregation/rate/src/test/test.js
+++ b/lib/aggregation/rate/src/test/test.js
@@ -858,7 +858,7 @@ describe('abacus-usage-rate', () => {
               locations[u.id] = val.headers.location;
               cb();
             }), undefined, () => {
-              // Check oauth validator spy$
+              // Check oauth validator spy
               expect(oauthspy.callCount).to.equal(secured ? usage.length : 0);
 
               done();

--- a/lib/aggregation/reporting/src/index.js
+++ b/lib/aggregation/reporting/src/index.js
@@ -217,12 +217,20 @@ const orgsUsage = function *(orgids, time) {
 };
 
 // Return the usage for an account in a given time period
-const accountUsage = function *(accountid, time) {
+const accountUsage = function *(authorization, accountid, time) {
   const t = time || Date.now();
+
+  // Forward authorization header field to account
+  const o = authorization ? {
+    headers: {
+      authorization: authorization
+    }
+  } : {};
+
   const account = yield brequest.get(
-    uris.account + '/v1/accounts/:account_id', {
+    uris.account + '/v1/accounts/:account_id', extend(o, {
       account_id: accountid
-    });
+    }));
   if(!account.body || !account.body.organizations)
     return undefined;
   return yield orgsUsage(account.body.organizations, t);
@@ -238,6 +246,10 @@ const graphSchema = new GraphQLSchema({
       organization: {
         type: organizationType,
         args: {
+          authorization: {
+            name: 'authorization',
+            type: GraphQLString
+          },
           organization_id: {
             name: 'organization_id',
             type: new GraphQLNonNull(GraphQLString)
@@ -255,6 +267,10 @@ const graphSchema = new GraphQLSchema({
       organizations: {
         type: new GraphQLList(organizationType),
         args: {
+          authorization: {
+            name: 'authorization',
+            type: GraphQLString
+          },
           organization_ids: {
             name: 'organization_ids',
             type: new GraphQLList(GraphQLString)
@@ -272,6 +288,10 @@ const graphSchema = new GraphQLSchema({
       account: {
         type: new GraphQLList(organizationType),
         args: {
+          authorization: {
+            name: 'authorization',
+            type: GraphQLString
+          },
           account_id: {
             name: 'account_id',
             type: new GraphQLNonNull(GraphQLString)
@@ -283,7 +303,7 @@ const graphSchema = new GraphQLSchema({
         },
         resolve: (root, args) => {
           return yieldable.promise(accountUsage)(
-              args.account_id, args.time);
+              args.authorization, args.account_id, args.time);
         }
       }
     })
@@ -332,8 +352,14 @@ routes.get(
     debug(
       'Retrieving rated usage using graphql query %s', req.params.query);
 
+    const q = req.headers.authroization ? req.params.query.replace(
+      /(.*)\((.*)/,
+      '$1(authorization:' + req.headers.authroization + ', $2') :
+      req.params.query;
+    debug('Modified graphql query %s', q)
+
     // Run the given GraphQL query and return the result
-    const doc = yield runQuery(req.params.query);
+    const doc = yield runQuery(q);
     debug('Graphql query result %o', doc);
 
     return {

--- a/lib/metering/collector/manifest.yml
+++ b/lib/metering/collector/manifest.yml
@@ -12,4 +12,3 @@ applications:
     COUCHDB: abacus-dbserver
     METER: abacus-usage-meter
     PROVISIONING: abacus-provisioning-stub
-

--- a/lib/metering/collector/src/index.js
+++ b/lib/metering/collector/src/index.js
@@ -19,6 +19,7 @@ const dataflow = require('abacus-dataflow');
 const oauth = require('abacus-cfoauth');
 
 const extend = _.extend;
+const pick = _.pick;
 
 const tmap = yieldable(transform.map);
 
@@ -43,8 +44,12 @@ const okey = (udoc) => udoc.organization_id;
 const otime = (udoc) => seqid();
 
 // Map submitted resource usage doc to normalized usage docs
-const normalizeUsage = function *(udoc) {
+const normalizeUsage = function *(udoc, opt) {
   debug('Normalizing usage %o', udoc);
+
+  // Forward authorization header field to provisioning
+  const o = opt && opt.authorization ?
+    { headers: pick(opt, 'authorization') } : {};
 
   // Validate the given region/org/space/consumer/resource/resource_instances
   yield tmap(udoc.usage, function *(u) {
@@ -52,7 +57,7 @@ const normalizeUsage = function *(udoc) {
       '/v1/provisioning/regions/:region/orgs/:organization_id/spaces/' +
       ':space_id/consumers/:consumer_id/resources/:resource_id/plans/' +
       ':plan_id/instances/:resource_instance_id',
-      extend({}, u, {
+      extend(o, u, {
         cache: true,
         consumer_id: u.consumer ? u.consumer.consumer_id : 'ALL'
       }));

--- a/lib/metering/meter/src/index.js
+++ b/lib/metering/meter/src/index.js
@@ -39,7 +39,7 @@ const measures = (mu) => {
 };
 
 // Apply the configured meter functions to the given usage
-const meterUsage = (udoc) => {
+const meterUsage = (udoc, opt) => {
   debug('Usage %o', udoc);
 
   // Translate the measured_usage to the measures object expected by

--- a/lib/utils/dataflow/src/index.js
+++ b/lib/utils/dataflow/src/index.js
@@ -20,6 +20,7 @@ const map = _.map;
 const object = _.object;
 const filter = _.filter;
 const pairs = _.pairs;
+const pick = _.pick;
 const without = _.without;
 const zip = _.zip;
 
@@ -138,25 +139,32 @@ const sink = function *(id, shost, spartition) {
 };
 
 // Post an output doc to the configured sink service
-const postOutput = function *(olog, shost, spartition, spost) {
+const postOutput = function *(olog, shost, spartition, spost, opt) {
   if(!spost)
     return;
   const phost = yield sink(olog.id, shost, spartition);
-  yieldable.functioncb(brequest.post)(phost + spost, {
-    body: olog
-  }, (err, res) => {
-    if(err)
-      edebug('Failed to post %s to sink, %o', olog.id, err);
-    else
-      debug('Posted %s to sink', olog.id);
-  });
+
+  // Forward authorization header field to sink service
+  const o = opt && opt.authorization ?
+    { headers: pick(opt, 'authorization') } : {};
+
+  yieldable.functioncb(brequest.post)(phost + spost,
+    extend(o, {
+      body: olog
+    }), (err, res) => {
+      if(err)
+        edebug('Failed to post %s to sink, %o', olog.id, err);
+      else
+        debug('Posted %s to sink', olog.id);
+    });
 };
 
 // Log an input doc and the corresponding output docs
 const log = function *(
   itype, idoc, ikey, itime, idb,
   otype, odocs, okey, otime, odb,
-  shost, spartition, spost) {
+  shost, spartition, spost,
+  opt) {
 
     // Log the input doc
   const ilog = yield logInput(idoc, ikey, itime, idb);
@@ -166,7 +174,7 @@ const log = function *(
     const olog = yield logOutput(itype, ilog, odoc, okey, otime, odb);
 
     // Post each output doc to the configured sink service
-    yield postOutput(olog, shost, spartition, spost);
+    yield postOutput(olog, shost, spartition, spost, opt);
 
     return olog.id;
   });
@@ -204,14 +212,18 @@ const mapper = (mapfn, opt) => {
     if(opt.input.schema)
       opt.input.schema.validate(req.body);
 
+    // Forward authorization header field to mapfn and log
+    const o = pick(req.headers, 'authorization');
+
     // Map the input doc to a list of output docs
-    const odocs = yield mapfn(req.body);
+    const odocs = yield mapfn(req.body, o);
 
     // Log the input doc and output docs
     const ids = yield log(
       opt.input.type, req.body, opt.input.key, opt.input.time, idb,
       opt.output.type, odocs, opt.output.key, opt.output.time, odb,
-      opt.sink.host, opt.sink.partition, opt.sink.post);
+      opt.sink.host, opt.sink.partition, opt.sink.post,
+      o);
 
     // Return the input and output doc locations
     return {

--- a/lib/utils/dataflow/src/test/test.js
+++ b/lib/utils/dataflow/src/test/test.js
@@ -44,7 +44,7 @@ describe('abacus-dataflow', () => {
 
       // Define a test map transform that computes the sum of a pair of
       // numbers
-      const sum = function *(doc) {
+      const sum = function *(doc, opt) {
         return [{
           val: doc.x + doc.y
         }];
@@ -95,6 +95,9 @@ describe('abacus-dataflow', () => {
 
       request.post('http://localhost::p/v1/pairs', {
         p: server.address().port,
+        auth: {
+          bearer: 'test'
+        },
         body: idoc
       }, (err, pval) => {
 
@@ -112,6 +115,9 @@ describe('abacus-dataflow', () => {
             val: 3
           };
           expect(reqmock.batch_post.args[0][0][0][1]).to.deep.equal({
+            headers: {
+              authorization: 'Bearer test'
+            },
             body: odoc
           });
 


### PR DESCRIPTION
Forward authorization header field to all services in the pipeline and to
external services. Enables authentication at all services using the bearer
access token presented to usage collector and usage reporting service.

See tracker [#101701306] and github issue #35.
