### PR TITLE
Fix batch request to handle non-200 HTTP response status codes

### DIFF
--- a/lib/aggregation/accumulator/src/test/test.js
+++ b/lib/aggregation/accumulator/src/test/test.js
@@ -26,7 +26,9 @@ require.cache[require.resolve('abacus-cluster')].exports =
 
 // Mock the request module
 const reqmock = extend({}, request, {
-  batch_post: spy((reqs, cb) => cb())
+  batch_post: spy((reqs, cb) => cb(undefined, [[undefined, {
+    statusCode: 200
+  }]]))
 });
 require.cache[require.resolve('abacus-request')].exports = reqmock;
 

--- a/lib/aggregation/aggregator/src/test/test.js
+++ b/lib/aggregation/aggregator/src/test/test.js
@@ -27,7 +27,9 @@ require.cache[require.resolve('abacus-cluster')].exports =
 
 // Mock the request module
 const reqmock = extend({}, request, {
-  batch_post: spy((reqs, cb) => cb())
+  batch_post: spy((reqs, cb) => cb(undefined, [[undefined, {
+    statusCode: 200
+  }]]))
 });
 require.cache[require.resolve('abacus-request')].exports = reqmock;
 

--- a/lib/metering/collector/src/test/test.js
+++ b/lib/metering/collector/src/test/test.js
@@ -27,7 +27,9 @@ const reqmock = extend({}, request, {
   batch_get: spy((reqs, cb) => cb(undefined, [[undefined, {
     statusCode: 200
   }]])),
-  batch_post: spy((reqs, cb) => cb())
+  batch_post: spy((reqs, cb) => cb(undefined, [[undefined, {
+    statusCode: 200
+  }]]))
 });
 require.cache[require.resolve('abacus-request')].exports = reqmock;
 

--- a/lib/metering/meter/src/test/test.js
+++ b/lib/metering/meter/src/test/test.js
@@ -23,7 +23,9 @@ require.cache[require.resolve('abacus-cluster')].exports =
 
 // Mock the request module
 const reqmock = extend({}, request, {
-  batch_post: spy((reqs, cb) => cb())
+  batch_post: spy((reqs, cb) => cb(undefined, [[undefined, {
+    statusCode: 200
+  }]]))
 });
 require.cache[require.resolve('abacus-request')].exports = reqmock;
 

--- a/lib/utils/dataflow/src/index.js
+++ b/lib/utils/dataflow/src/index.js
@@ -155,7 +155,8 @@ const postOutput = function *(olog, shost, spartition, spost, opt) {
       if(err)
         edebug('Failed to post %s to sink, %o', olog.id, err);
       else
-        debug('Posted %s to sink', olog.id);
+        debug('Posted %s to sink, received response code %d', olog.id,
+          res.statusCode);
     });
 };
 

--- a/lib/utils/dataflow/src/test/test.js
+++ b/lib/utils/dataflow/src/test/test.js
@@ -23,7 +23,9 @@ const reqmock = extend({}, request, {
   batch_get: spy((reqs, cb) => cb(undefined, [[undefined, {
     statusCode: 200
   }]])),
-  batch_post: spy((reqs, cb) => cb())
+  batch_post: spy((reqs, cb) => cb(undefined, [[undefined, {
+    statusCode: 200
+  }]]))
 });
 require.cache[require.resolve('abacus-request')].exports = reqmock;
 

--- a/lib/utils/request/src/index.js
+++ b/lib/utils/request/src/index.js
@@ -243,10 +243,24 @@ const batchOp = (m, opt) => {
 
             // Return the list of results from the response body
             if(bres) {
-              // Handle 404 response from /batch
-              if (bres.statusCode === 404)
-                return gcb(undefined, map(group, (g) => ({ i: g.i,
-                  res: [undefined, bres] })));
+              // Forward non-200 status codes from /batch to requests
+              const httpres = () => {
+                edebug('Received batch response %d %o %o', bres.statusCode,
+                  pick(bres.headers, 'www-authenticate') || '',
+                  bres.body || '');
+                debug('Batch error response %d %o %o', bres.statusCode,
+                  pick(bres.headers, 'www-authenticate') || '',
+                  bres.body || '');
+
+                return gcb(undefined, map(group, (g) => ({
+                  i: g.i,
+                  res: [undefined, extend({}, bres,
+                  bres.statusCode === 404 ? { statusCode: 405 } : {})]
+                })));
+              }
+
+              // Handle non-200 status codes from /batch
+              if (bres.statusCode != 200) return httpres();
 
               gcb(undefined, map(bres.body, (r, i) => {
                 if(r.statusCode >= 500 && r.statusCode <= 599)

--- a/lib/utils/request/src/test/test.js
+++ b/lib/utils/request/src/test/test.js
@@ -250,7 +250,7 @@ describe('abacus-request', () => {
     });
   });
 
-  it('batches HTTP request to an invalid URL', (done) => {
+  it('batches HTTP request to a server that does not support batch', (done) => {
     // Create a test HTTP server
     const server = http.createServer((req, res) => {
       if (req.url === '/batch') {
@@ -282,8 +282,46 @@ describe('abacus-request', () => {
         r: 'request'
       }, (err, val) => {
         expect(err).to.equal(undefined);
-        expect(val.statusCode).to.equal(404);
+        expect(val.statusCode).to.equal(405);
         expect(val.body).to.deep.equal({ error: 'Not found' });
+        done();
+      });
+    });
+  });
+
+  it('batches HTTP request to a server and expect a 401 response', (done) => {
+    // Create a test HTTP server
+    const server = http.createServer((req, res) => {
+      if (req.url === '/batch') {
+        // Return 401
+        res.statusCode = 401;
+        res.setHeader('WWW-Authenticate', 'Bearer')
+        res.end();
+      }
+    });
+
+    // Listen on an ephemeral port
+    server.listen(0);
+
+    // Wait for the server to become available
+    request.waitFor('http://localhost::p/batch', {
+      p: server.address().port
+    }, (err, val) => {
+      if(err)
+        throw err;
+
+      // Use a batch version of the request module
+      const brequest = batch(request);
+
+      // Send an HTTP request, expecting a 401 response
+      brequest.get('http://localhost::p/:v/:r', {
+        p: server.address().port,
+        v: 'unauthorized',
+        r: 'request'
+      }, (err, val) => {
+        expect(err).to.equal(undefined);
+        expect(val.statusCode).to.equal(401);
+        expect(val.headers['www-authenticate']).to.equal('Bearer');
         done();
       });
     });


### PR DESCRIPTION
Forward non-200 HTTP response status codes for a /batch request to individual
requests in the batch. Differentiate batch response status code 404, by
translating it into status code 405.

Add batch HTTP response code and error details to logs.

See tracker [#101701306] and github issue #35.
