### PR TITLE
Group batch requests by OAuth bearer access token in addition to URL

### DIFF
--- a/lib/utils/request/src/index.js
+++ b/lib/utils/request/src/index.js
@@ -225,9 +225,11 @@ const batchOp = (m, opt) => {
       const targets = filter(res, (t) => !t.cached);
 
       // Send the remaining requests, group the calls by target
-      // protocol, auth and host
-      const groups = map(groupBy(targets, (t) => url.resolve(t.target.uri,
-        '/')));
+      // protocol, auth, host and OAuth bearer access token
+      const groups = map(groupBy(targets, (t) =>
+        [url.resolve(t.target.uri, '/'),
+        t.target.options.headers && t.target.options.headers.authorization ?
+        t.target.options.headers.authorization : ''].join('-')));
 
       // Send a single HTTP request per group
       transform.map(groups, (group, g, groups, gcb) => {
@@ -236,9 +238,14 @@ const batchOp = (m, opt) => {
           (t) => extend({ uri: url.parse(t.target.uri).path },
             pick(t.target.options, 'method', 'headers', 'json', 'body')));
 
+        // Use the group's OAuth bearer access token for POST request
+        const o = greq[0].headers && greq[0].headers.authorization ? {
+          headers:  pick(greq[0].headers, 'authorization')
+        } : {};
+
         // Send the POST request to the target's host /batch path
-        post(url.resolve(group[0].target.uri, '/batch'), { body: greq },
-          (err, bres) => {
+        post(url.resolve(group[0].target.uri, '/batch'), extend(o,
+          { body: greq }), (err, bres) => {
             if(err) return gcb(err);
 
             // Return the list of results from the response body

--- a/lib/utils/request/src/test/test.js
+++ b/lib/utils/request/src/test/test.js
@@ -289,41 +289,77 @@ describe('abacus-request', () => {
     });
   });
 
-  it('batches HTTP request to a server and expect a 401 response', (done) => {
-    // Create a test HTTP server
-    const server = http.createServer((req, res) => {
-      if (req.url === '/batch') {
-        // Return 401
-        res.statusCode = 401;
-        res.setHeader('WWW-Authenticate', 'Bearer')
-        res.end();
-      }
-    });
+  it('batches HTTP requests using valid and invalid authorization tokens',
+    (done) => {
+      let batches = 0;
+      // Create a test HTTP server
+      const server = http.createServer((req, res) => {
+        // Handle batched requests
+        if (req.url === '/batch') {
+          if (req.headers.authorization) batches++;
 
-    // Listen on an ephemeral port
-    server.listen(0);
+          if (req.headers.authorization === 'Bearer valid') {
+            res.statusCode = 200;
+            res.setHeader('Content-type', 'application/json');
+            res.end(JSON.stringify([{ statusCode: 200, body: 'okay' }]));
+          }
+          else {
+            res.statusCode = 401;
+            res.setHeader('WWW-Authenticate', 'Bearer')
+            res.end();
+          }
+        }
+      });
 
-    // Wait for the server to become available
-    request.waitFor('http://localhost::p/batch', {
-      p: server.address().port
-    }, (err, val) => {
-      if(err)
-        throw err;
+      // Listen on an ephemeral port
+      server.listen(0);
 
-      // Use a batch version of the request module
-      const brequest = batch(request);
-
-      // Send an HTTP request, expecting a 401 response
-      brequest.get('http://localhost::p/:v/:r', {
-        p: server.address().port,
-        v: 'unauthorized',
-        r: 'request'
+      // Wait for the server to become available
+      request.waitFor('http://localhost::p/batch', {
+        p: server.address().port
       }, (err, val) => {
-        expect(err).to.equal(undefined);
-        expect(val.statusCode).to.equal(401);
-        expect(val.headers['www-authenticate']).to.equal('Bearer');
-        done();
+        if(err)
+          throw err;
+
+        let cbs = 0;
+        const done1 = () => {
+          if(++cbs === 2) {
+            expect(batches).to.equal(2);
+            done();
+          }
+        };
+
+        // Use a batch version of the request module
+        const brequest = batch(request);
+
+        // Send an HTTP request, expecting an OK response
+        brequest.get('http://localhost::p/:v/:r', {
+          p: server.address().port,
+          v: 'ok',
+          r: 'request',
+          headers: {
+            authorization: 'Bearer valid'
+          }
+        }, (err, val) => {
+          expect(err).to.equal(undefined);
+          expect(val.statusCode).to.equal(200);
+          expect(val.body).to.equal('okay');
+          done1();
+        });
+
+        brequest.get('http://localhost::p/:v/:r', {
+          p: server.address().port,
+          v: 'ok',
+          r: 'request',
+          headers: {
+            authorization: 'Bearer invalid'
+          }
+        }, (err, val) => {
+          expect(err).to.equal(undefined);
+          expect(val.statusCode).to.equal(401);
+          expect(val.headers['www-authenticate']).to.equal('Bearer');
+          done1();
+        });
       });
     });
-  });
 });


### PR DESCRIPTION
Add OAuth bearer access token to list of properties that uniquely identifies
a group of requests in a batch. Then use the group's OAuth bearer access token
to authenticate the batch POST request for that group.

See tracker [#101701306] and github issue #35.
