### PR TITLE
Batch all routes defined at application rather than just at a router

### DIFF
--- a/lib/aggregation/accumulator/src/index.js
+++ b/lib/aggregation/accumulator/src/index.js
@@ -363,7 +363,7 @@ const accumulator = () => {
       oauth.validator(process.env.JWTKEY, process.env.JWTALGO));
 
   app.use(routes);
-  app.use(router.batch(routes));
+  app.use(router.batch(app));
   return app;
 };
 

--- a/lib/aggregation/accumulator/src/test/test.js
+++ b/lib/aggregation/accumulator/src/test/test.js
@@ -565,7 +565,7 @@ describe('abacus-usage-accumulator', () => {
           expect(val.statusCode).to.equal(200);
 
           // Check oauth validator spy
-          expect(oauthspy.callCount).to.equal(secured ? 2 : 0);
+          expect(oauthspy.callCount).to.equal(secured ? 3 : 0);
 
           done();
         });

--- a/lib/aggregation/aggregator/src/index.js
+++ b/lib/aggregation/aggregator/src/index.js
@@ -458,7 +458,7 @@ const aggregator = () => {
       oauth.validator(process.env.JWTKEY, process.env.JWTALGO));
 
   app.use(routes);
-  app.use(router.batch(routes));
+  app.use(router.batch(app));
   return app;
 };
 

--- a/lib/aggregation/aggregator/src/test/test.js
+++ b/lib/aggregation/aggregator/src/test/test.js
@@ -1870,7 +1870,7 @@ describe('abacus-usage-aggregator', () => {
             expect(check).to.equal(true);
 
             // Check oauth validator spy
-            expect(oauthspy.callCount).to.equal(secured ? 5 : 0);
+            expect(oauthspy.callCount).to.equal(secured ? 9 : 0);
 
             done();
           });

--- a/lib/aggregation/rate/src/index.js
+++ b/lib/aggregation/rate/src/index.js
@@ -346,7 +346,7 @@ const rateapp = () => {
       oauth.validator(process.env.JWTKEY, process.env.JWTALGO));
 
   app.use(routes);
-  app.use(router.batch(routes));
+  app.use(router.batch(app));
   return app;
 };
 

--- a/lib/aggregation/rate/src/test/test.js
+++ b/lib/aggregation/rate/src/test/test.js
@@ -2200,7 +2200,7 @@ describe('abacus-usage-rate', () => {
             if(++cbs === usage.length) {
               // Check oauth validator spy
               expect(oauthspy.callCount).to.equal(secured ?
-                usage.length + 1 : 0);
+                usage.length * 2 + 1 : 0);
 
               done();
             }

--- a/lib/aggregation/reporting/src/index.js
+++ b/lib/aggregation/reporting/src/index.js
@@ -423,7 +423,7 @@ const reporting = () => {
       oauth.validator(process.env.JWTKEY, process.env.JWTALGO));
 
   app.use(routes);
-  app.use(router.batch(routes));
+  app.use(router.batch(app));
   return app;
 };
 

--- a/lib/aggregation/reporting/src/test/test.js
+++ b/lib/aggregation/reporting/src/test/test.js
@@ -4128,7 +4128,7 @@ describe('abacus-usage-report', () => {
           expect(val.body).to.deep.equal(expected);
 
           // Check oauth validator spy
-          expect(oauthspy.callCount).to.equal(secured ? 1 : 0);
+          expect(oauthspy.callCount).to.equal(secured ? 2 : 0);
 
           done();
         });


### PR DESCRIPTION
Defines batch routes using application routes. Enables handling all individual
responses inside the batch middleware scope and avoids prematurely ending the
batch response as a whole.

Related to [#102364254] at Pivotal Tracker.
See tracker [#101701306] and github issue #35.
