### PR TITLE
Secure account stub REST endpoints using OAuth bearer token

### DIFF
--- a/lib/stubs/account/manifest.yml
+++ b/lib/stubs/account/manifest.yml
@@ -5,4 +5,7 @@ applications:
   instances: 2
   memory: 512M
   disk_quota: 512M
-
+  env:
+    SECURED: false
+    JWTKEY: undefined
+    JWTALGO: undefined

--- a/lib/stubs/account/package.json
+++ b/lib/stubs/account/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "babel-runtime": "^5.8.19",
+    "abacus-cfoauth": "file:../../utils/cfoauth",
     "abacus-debug": "file:../../utils/debug",
     "abacus-router": "file:../../utils/router",
     "abacus-usage-schemas": "file:../../config/schemas",

--- a/lib/stubs/account/src/index.js
+++ b/lib/stubs/account/src/index.js
@@ -8,6 +8,7 @@
 const _ = require('underscore');
 const webapp = require('abacus-webapp');
 const router = require('abacus-router');
+const oauth = require('abacus-cfoauth');
 const schemas = require('abacus-usage-schemas');
 
 const extend = _.extend;
@@ -16,6 +17,9 @@ const extend = _.extend;
 
 // Setup debug log
 const debug = require('abacus-debug')('abacus-account-stub');
+
+// Secure the routes or not
+const secured = () => process.env.SECURED === 'true' ? true : false;
 
 // Create an express router
 const routes = router();
@@ -90,8 +94,15 @@ routes.get(
 // Create an account management stub application
 const accountManagement = () => {
   const app = webapp();
+
+  // Secure accounts, orgs, pricing and batch routes using an OAuth
+  // bearer access token
+  if (secured())
+    app.use(/^\/v1\/(accounts|orgs|pricing)|^\/batch$/,
+      oauth.validator(process.env.JWTKEY, process.env.JWTALGO));
+
   app.use(routes);
-  app.use(router.batch(routes));
+  app.use(router.batch(app));
   return app;
 };
 
@@ -101,4 +112,3 @@ const runCLI = () => accountManagement().listen();
 // Export our public functions
 module.exports = accountManagement;
 module.exports.runCLI = runCLI;
-

--- a/lib/stubs/account/src/test/test.js
+++ b/lib/stubs/account/src/test/test.js
@@ -4,20 +4,34 @@
 
 const _ = require('underscore');
 const request = require('abacus-request');
+const batch = require('abacus-batch');
 const cluster = require('abacus-cluster');
+const oauth = require('abacus-cfoauth');
 const schemas = require('abacus-usage-schemas');
 
 const extend = _.extend;
 const map = _.map;
 
+const brequest = batch(request);
+
 // Mock the cluster module
 require.cache[require.resolve('abacus-cluster')].exports =
   extend((app) => app, cluster);
+
+// Mock the oauth module with a spy
+const oauthspy = spy((req, res, next) => next());
+const oauthmock = extend({}, oauth, {
+  validator: () => oauthspy
+});
+require.cache[require.resolve('abacus-cfoauth')].exports = oauthmock;
 
 const accountManagement = require('..');
 
 describe('abacus-account-stub', () => {
   it('returns information about an account', (done) => {
+    process.env.SECURED = 'false';
+    oauthspy.reset();
+
     // Create an account management stub application
     const app = accountManagement();
 
@@ -40,11 +54,18 @@ describe('abacus-account-stub', () => {
       expect(err).to.equal(undefined);
       expect(val.statusCode).to.equal(200);
       expect(val.body).to.deep.equal(account);
+
+      // Check oauth validator spy
+      expect(oauthspy.callCount).to.equal(0);
+
       done();
     });
   });
 
   it('returns information about the account containing an org', (done) => {
+    process.env.SECURED = 'false';
+    oauthspy.reset();
+
     // Create an account management stub application
     const app = accountManagement();
 
@@ -64,11 +85,18 @@ describe('abacus-account-stub', () => {
       expect(err).to.equal(undefined);
       expect(val.statusCode).to.equal(200);
       expect(val.body).to.deep.equal(account);
+
+      // Check oauth validator spy
+      expect(oauthspy.callCount).to.equal(0);
+
       done();
     });
   });
 
   it('returns a resource price config', (done) => {
+    process.env.SECURED = 'false';
+    oauthspy.reset();
+
     // Create a test account management stub app
     const app = accountManagement();
 
@@ -86,7 +114,80 @@ describe('abacus-account-stub', () => {
         expect(val.statusCode).to.equal(200);
         expect(val.body).to.deep.equal(
           require('../resources/object-storage'));
+
+        // Check oauth validator spy
+        expect(oauthspy.callCount).to.equal(0);
+
         done();
+      });
+  });
+
+  it('Run a secured account management stub', (done) => {
+    process.env.SECURED = 'true';
+    oauthspy.reset();
+
+    // Create an account management stub application
+    const app = accountManagement();
+
+    // Listen on an ephemeral port
+    const server = app.listen(0);
+
+    let cbs = 0;
+    const done1 = () => {
+      if(++cbs === 3) {
+        // Check oauth validator spy
+        expect(oauthspy.callCount).to.equal(4);
+        done();
+      }
+    }
+
+    // Get an account, expecting our stub test account
+    const account = {
+      account_id: '5678',
+      organizations: [
+        'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
+        'b3d7fe4d-3cb1-4cc3-a831-ffe98e20cf28',
+        'c3d7fe4d-3cb1-4cc3-a831-ffe98e20cf29'],
+      pricing_country: 'USA'
+    };
+    brequest.get('http://localhost::p/v1/accounts/:account_id', {
+      p: server.address().port,
+      account_id: '5678'
+    }, (err, val) => {
+      expect(err).to.equal(undefined);
+      expect(val.statusCode).to.equal(200);
+      expect(val.body).to.deep.equal(account);
+      done1();
+    });
+
+    // Get the account containing an org, expecting our stub test account
+    brequest.get('http://localhost::p/v1/orgs/:org_id/account', {
+      p: server.address().port,
+      org_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27'
+    }, (err, val) => {
+      expect(err).to.equal(undefined);
+      expect(val.statusCode).to.equal(200);
+      expect(val.body).to.deep.equal({
+        account_id: '1234',
+        organizations: ['a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27'],
+        pricing_country: 'USA'
+      });
+      done1();
+    });
+
+    // Get Pricing config for a resource
+    brequest.get(
+      'http://localhost::p/v1/pricing/resources' +
+      '/:resource_id/config/:time', {
+        p: server.address().port,
+        resource_id: 'object-storage',
+        time: 1420070400000
+      }, (err, val) => {
+        expect(err).to.equal(undefined);
+        expect(val.statusCode).to.equal(200);
+        expect(val.body).to.deep.equal(
+          require('../resources/object-storage'));
+        done1();
       });
   });
 
@@ -99,4 +200,3 @@ describe('abacus-account-stub', () => {
     });
   });
 });
-


### PR DESCRIPTION
Define SECURED environment variable to enable authenticating incoming requests.

Define JWTKEY and JWTALGO environment variables to configure JWT-JWS based
bearer access token validation.

Add OAuth validator middleware to /v1/accounts, /v1/orgs, /v1/pricing and
/batch routes and update unit tests.

See tracker [#101701306] and github issue #35.
