### PR TITLE
Set individual response header values for a batch request

### DIFF
--- a/lib/utils/router/src/index.js
+++ b/lib/utils/router/src/index.js
@@ -14,6 +14,7 @@ const transform = require('abacus-transform');
 const toArray = _.toArray;
 const map = _.map;
 const extend = _.extend;
+const omit = _.omit;
 const pick = _.pick;
 const without = _.without;
 const allKeys = _.allKeys;
@@ -169,6 +170,11 @@ const batch = (routes) => {
           rres.statusCode = s;
           return rres;
         },
+        header: (k, v) => {
+          if (!rres.header) rres.header = {};
+          rres.header[k] = v;
+          return rres;
+        },
         send: (b) => {
           rres.body = b;
           return rres.end();
@@ -180,6 +186,7 @@ const batch = (routes) => {
         end: () => {
           rcb(undefined, {
             statusCode: rres.statusCode,
+            header: omit(rres.header, 'setHeader'),
             body: rres.body
           });
           return rres;


### PR DESCRIPTION
Respond back to a batch request with individual response headers as part of
the batch response body.

Fixes [#105281266] at Pivotal Tracker and github issue #77.
