### PR TITLE
Replace object argument named opt with a string argument named auth

### DIFF
--- a/lib/aggregation/accumulator/src/index.js
+++ b/lib/aggregation/accumulator/src/index.js
@@ -25,7 +25,6 @@ const map = _.map;
 const last = _.last;
 const extend = _.extend;
 const omit = _.omit;
-const pick = _.pick;
 const filter = _.filter;
 
 const treduce = yieldable(transform.reduce);
@@ -257,7 +256,7 @@ const updateAccumulatedUsage =
   })));
 
 // Accumulate the given usage
-const accumulateUsage = function *(u, opt) {
+const accumulateUsage = function *(u, auth) {
   // Compute the usage log id and accumulated usage id
   const k = [u.organization_id, u.resource_instance_id, u.plan_id].join('/');
   const ulogid = dbclient.kturi(k, [u.end, u.start, u.end].join('/'));
@@ -282,8 +281,7 @@ const accumulateUsage = function *(u, opt) {
   });
 
   // Forward authorization header field to usage aggregator
-  const o = opt && opt.authorization ?
-    { headers: pick(opt, 'authorization') } : {};
+  const o = auth ? { headers: { authorization: auth } } : {};
 
   yieldable.functioncb(brequest.post)(
     (yield aggreguri(alogdoc.organization_id, alogdoc.start)) +
@@ -306,10 +304,12 @@ const routes = router();
 // Accumulate usage for a given resource instance
 routes.post('/v1/metering/metered/usage', throttle(function *(req) {
   const u = req.body;
+  const auth = req.headers && req.headers.authorization ?
+    req.headers.authorization : undefined;
 
   // Accumulate usage
   debug('Accumulating usage %o', u);
-  const id = yield accumulateUsage(u, pick(req.headers, 'authorization'));
+  const id = yield accumulateUsage(u, auth);
 
   // Return the location of the new accumulated usage
   return {

--- a/lib/aggregation/aggregator/src/index.js
+++ b/lib/aggregation/aggregator/src/index.js
@@ -26,7 +26,6 @@ const map = _.map;
 const last = _.last;
 const extend = _.extend;
 const omit = _.omit;
-const pick = _.pick;
 
 const tmap = yieldable(transform.map);
 const treduce = yieldable(transform.reduce);
@@ -358,7 +357,7 @@ const updateAggregatedUsage =
   })));
 
 // Aggregate the given accumulated usage
-const aggregateUsage = function *(u, opt) {
+const aggregateUsage = function *(u, auth) {
   // Compute the usage log id and aggregated usage id
   const aid = dbclient.kturi(u.organization_id, 0);
   const alogid = dbclient.kturi(u.organization_id,
@@ -380,8 +379,7 @@ const aggregateUsage = function *(u, opt) {
   });
 
   // Forward authorization header field to rating service
-  const o = opt && opt.authorization ?
-    { headers: pick(opt, 'authorization') } : {};
+  const o = auth ? { headers: { authorization: auth } } : {};
 
   // Post the new aggregated usage to the rating service
   yieldable.functioncb(brequest.post)(
@@ -403,10 +401,12 @@ const routes = router();
 // Aggregate accumulated usage for a given resource instance
 routes.post('/v1/metering/accumulated/usage', throttle(function *(req) {
   const u = req.body;
+  const auth = req.headers && req.headers.authorization ?
+    req.headers.authorization : undefined;
 
   // Aggregate usage
   debug('Aggregating usage %o', u);
-  const id = yield aggregateUsage(u, pick(req.headers, 'authorization'));
+  const id = yield aggregateUsage(u, auth);
 
   // Return the location of the new aggregated usage
   return {

--- a/lib/aggregation/rate/src/index.js
+++ b/lib/aggregation/rate/src/index.js
@@ -27,7 +27,6 @@ const map = _.map;
 const last = _.last;
 const extend = _.extend;
 const omit = _.omit;
-const pick = _.pick;
 
 const tmap = yieldable(transform.map);
 const treduce = yieldable(transform.reduce);
@@ -65,10 +64,9 @@ const loc = (req, template, params) => req.protocol + '://' +
   req.headers.host + request.route(template, params);
 
 // Return the pricing country configured for an organization's account
-const pricingCountry = function *(oid, opt) {
+const pricingCountry = function *(oid, auth) {
   // Forward authorization header field to account
-  const o = opt && opt.authroization ?
-    { headers: pick(opt, 'authorization') } : {};
+  const o = auth ? { headers: { authorization: auth } } : {};
 
   const account = yield brequest.get(
     uris.account + '/v1/orgs/:org_id/account', extend(o, {
@@ -82,9 +80,9 @@ const pricingCountry = function *(oid, opt) {
 
 // Return the configured price for the given resource, plan, metric, and
 // country
-const price = function *(rid, pid, metric, country, time) {
+const price = function *(rid, pid, metric, country, time, auth) {
   // Retrieve the resource price config
-  const resource = yield prices(rid, time);
+  const resource = yield prices(rid, time, auth);
   if(resource) {
     // Find the specified plan
     const plan = filter(resource.plans, (p) => p.plan_id === pid);
@@ -106,7 +104,7 @@ const ratefn = (metrics, metric) => {
 };
 
 // Rates the given aggregated usage
-const rate = function *(r, u, pc) {
+const rate = function *(r, u, pc, auth) {
   // Rate the aggregated usage under a resource
   const rateResource = function *(rs) {
 
@@ -131,7 +129,7 @@ const rate = function *(r, u, pc) {
 
             // Return the metric along with the calculated cost
             const rp = yield price(
-              rs.resource_id, p.plan_id, m.metric, pc, u.end);
+              rs.resource_id, p.plan_id, m.metric, pc, u.end, auth);
             return extend({}, omit(m, 'quantity'), {
               windows: map(m.quantity, (q) => ({
                 quantity: q,
@@ -221,11 +219,11 @@ const updateRatedUsage =
 
       // Retrieve the pricing country configured for the org's account
       const pc = yield pricingCountry(calls[0][0].u.organization_id,
-        calls[0][0].opt);
+        calls[0][0].auth);
 
       // Rate the usage docs
       const rres = yield treduce(calls, function *(rres, call) {
-        const newr = yield rate(rres.newr, call[0].u, pc);
+        const newr = yield rate(rres.newr, call[0].u, pc, call[0].auth);
         return {
           newr: newr,
           ares: rres.ares.concat([[undefined, omit(newr, 'dbrev')]])
@@ -254,11 +252,11 @@ const updateRatedUsage =
     }
   }, function *(args) {
     // Group calls by rated usage id
-    return args[0].rid;
+    return [args[0].rid, args[0].auth ? args[0].auth : ''].join('-');
   })));
 
 // Rate the given aggregated usage
-const rateUsage = function *(u, opt) {
+const rateUsage = function *(u, auth) {
   // Compute the rated usage id and the rated usage log id
   const rid = dbclient.kturi(u.organization_id, 0);
   const rlogid = dbclient.kturi(u.organization_id, [
@@ -266,7 +264,7 @@ const rateUsage = function *(u, opt) {
 
   // Rate the usage
   const newr = yield updateRatedUsage({
-    u: u, rid: rid, rlogid: rlogid, uid: u.id, opt: opt });
+    u: u, rid: rid, rlogid: rlogid, uid: u.id, auth: auth });
 
   // Log the rated usage
   const rlogdoc = extend(dbclient.undbify(newr), {
@@ -290,9 +288,11 @@ routes.post('/v1/rating/usage', throttle(function *(req) {
     statusCode: 400
   };
   const u = req.body;
+  const auth = req.headers && req.headers.authorization ?
+    req.headers.authorization : undefined;
 
   // Rate the usage
-  const id = yield rateUsage(u, pick(req.headers, 'authorization'));
+  const id = yield rateUsage(u, auth);
 
   return {
     statusCode: 201,

--- a/lib/aggregation/reporting/src/index.js
+++ b/lib/aggregation/reporting/src/index.js
@@ -257,15 +257,11 @@ const orgsUsage = function *(orgids, time) {
 };
 
 // Return the usage for an account in a given time period
-const accountUsage = function *(authorization, accountid, time) {
+const accountUsage = function *(accountid, time, auth) {
   const t = time || Date.now();
 
   // Forward authorization header field to account
-  const o = authorization ? {
-    headers: {
-      authorization: authorization
-    }
-  } : {};
+  const o = auth ? { headers: { authorization: auth } } : {};
 
   const account = yield brequest.get(
     uris.account + '/v1/accounts/:account_id', extend(o, {
@@ -286,10 +282,6 @@ const graphSchema = new GraphQLSchema({
       organization: {
         type: organizationType,
         args: {
-          authorization: {
-            name: 'authorization',
-            type: GraphQLString
-          },
           organization_id: {
             name: 'organization_id',
             type: new GraphQLNonNull(GraphQLString)
@@ -297,6 +289,10 @@ const graphSchema = new GraphQLSchema({
           time: {
             name: 'time',
             type: GraphQLInt
+          },
+          authorization: {
+            name: 'authorization',
+            type: GraphQLString
           }
         },
         resolve: (root, args) => {
@@ -307,10 +303,6 @@ const graphSchema = new GraphQLSchema({
       organizations: {
         type: new GraphQLList(organizationType),
         args: {
-          authorization: {
-            name: 'authorization',
-            type: GraphQLString
-          },
           organization_ids: {
             name: 'organization_ids',
             type: new GraphQLList(GraphQLString)
@@ -318,6 +310,10 @@ const graphSchema = new GraphQLSchema({
           time: {
             name: 'time',
             type: GraphQLInt
+          },
+          authorization: {
+            name: 'authorization',
+            type: GraphQLString
           }
         },
         resolve: (root, args) => {
@@ -328,10 +324,6 @@ const graphSchema = new GraphQLSchema({
       account: {
         type: new GraphQLList(organizationType),
         args: {
-          authorization: {
-            name: 'authorization',
-            type: GraphQLString
-          },
           account_id: {
             name: 'account_id',
             type: new GraphQLNonNull(GraphQLString)
@@ -339,11 +331,15 @@ const graphSchema = new GraphQLSchema({
           time: {
             name: 'time',
             type: GraphQLInt
+          },
+          authorization: {
+            name: 'authorization',
+            type: GraphQLString
           }
         },
         resolve: (root, args) => {
           return yieldable.promise(accountUsage)(
-              args.authorization, args.account_id, args.time);
+            args.account_id, args.time, args.authorization);
         }
       }
     })

--- a/lib/config/price/src/index.js
+++ b/lib/config/price/src/index.js
@@ -2,6 +2,7 @@
 
 // Provides access to resource pricing configuration.
 
+const _ = require('underscore');
 const request = require('abacus-request');
 const breaker = require('abacus-breaker');
 const retry = require('abacus-retry');
@@ -9,6 +10,8 @@ const batch = require('abacus-batch');
 const urienv = require('abacus-urienv');
 const lock = require('abacus-lock');
 const lru = require('lru-cache');
+
+const extend = _.extend;
 
 const brequest = retry(breaker(batch(request)));
 
@@ -41,7 +44,7 @@ const cached = (k) => {
 };
 
 // Retrieve the price config for the specified resource and time
-const config = (rid, time, cb) => {
+const config = (rid, time, auth, cb) => {
   // Round time to a 10 min boundary
   const t = Math.floor(time / 600000) * 600000;
   const k = [rid, t].join('/');
@@ -60,12 +63,15 @@ const config = (rid, time, cb) => {
       return unlock(
         cb(undefined, cache(k, require('./test/test-resource'))));
 
+    // Forward authorization header field to account
+    const o = auth ? { headers: { authorization: auth } } : {};
+
     // Get the requested resource price config from the account service
     return brequest.get(uris.account +
-      '/v1/pricing/resources/:resource_id/config/:time', {
+      '/v1/pricing/resources/:resource_id/config/:time', extend(o, {
         resource_id: rid,
         time: t
-      }, (err, val) => {
+      }), (err, val) => {
         if(err)
           return cb(err);
 
@@ -77,4 +83,3 @@ const config = (rid, time, cb) => {
 
 // Export our public functions
 module.exports = config;
-

--- a/lib/config/price/src/test/test.js
+++ b/lib/config/price/src/test/test.js
@@ -13,17 +13,16 @@ describe('abacus-price-config', () => {
 
     // Retrieve a resource config
     const t = 1420070400000;
-    config('test-resource', t, (err, val) => {
+    config('test-resource', t, undefined, (err, val) => {
       expect(err).to.equal(undefined);
       expect(val).to.deep.equal(require('./test-resource.js'));
       cb();
     })
     // Retrieve it again, this time it should be returned from the cache
-    config('test-resource', t, (err, val) => {
+    config('test-resource', t, undefined, (err, val) => {
       expect(err).to.equal(undefined);
       expect(val).to.deep.equal(require('./test-resource.js'));
       cb();
     })
   });
 });
-

--- a/lib/metering/collector/src/index.js
+++ b/lib/metering/collector/src/index.js
@@ -19,7 +19,6 @@ const dataflow = require('abacus-dataflow');
 const oauth = require('abacus-cfoauth');
 
 const extend = _.extend;
-const pick = _.pick;
 
 const tmap = yieldable(transform.map);
 
@@ -44,12 +43,11 @@ const okey = (udoc) => udoc.organization_id;
 const otime = (udoc) => seqid();
 
 // Map submitted resource usage doc to normalized usage docs
-const normalizeUsage = function *(udoc, opt) {
+const normalizeUsage = function *(udoc, auth) {
   debug('Normalizing usage %o', udoc);
 
   // Forward authorization header field to provisioning
-  const o = opt && opt.authorization ?
-    { headers: pick(opt, 'authorization') } : {};
+  const o = auth ? { headers: { authorization: auth } } : {};
 
   // Validate the given region/org/space/consumer/resource/resource_instances
   yield tmap(udoc.usage, function *(u) {

--- a/lib/metering/meter/src/index.js
+++ b/lib/metering/meter/src/index.js
@@ -42,7 +42,7 @@ const measures = (mu) => {
 };
 
 // Apply the configured meter functions to the given usage
-const meterUsage = function *(udoc, opt) {
+const meterUsage = function *(udoc, auth) {
   debug('Usage %o', udoc);
 
   // Translate the measured_usage to the measures object expected by

--- a/lib/utils/dataflow/src/index.js
+++ b/lib/utils/dataflow/src/index.js
@@ -20,7 +20,6 @@ const map = _.map;
 const object = _.object;
 const filter = _.filter;
 const pairs = _.pairs;
-const pick = _.pick;
 const without = _.without;
 const zip = _.zip;
 
@@ -140,14 +139,13 @@ const sink = function *(id, shost, spartition) {
 };
 
 // Post an output doc to the configured sink service
-const postOutput = function *(olog, shost, spartition, spost, opt) {
+const postOutput = function *(olog, shost, spartition, spost, auth) {
   if(!spost)
     return;
   const phost = yield sink(olog.id, shost, spartition);
 
   // Forward authorization header field to sink service
-  const o = opt && opt.authorization ?
-    { headers: pick(opt, 'authorization') } : {};
+  const o = auth ? { headers: { authorization: auth } } : {};
 
   yieldable.functioncb(brequest.post)(phost + spost,
     extend(o, {
@@ -166,7 +164,7 @@ const log = function *(
   itype, idoc, ikey, itime, idb,
   otype, odocs, okey, otime, odb,
   shost, spartition, spost,
-  opt) {
+  auth) {
 
     // Log the input doc
   const ilog = yield logInput(idoc, ikey, itime, idb);
@@ -176,7 +174,7 @@ const log = function *(
     const olog = yield logOutput(itype, ilog, odoc, okey, otime, odb);
 
     // Post each output doc to the configured sink service
-    yield postOutput(olog, shost, spartition, spost, opt);
+    yield postOutput(olog, shost, spartition, spost, auth);
 
     return olog.id;
   });
@@ -215,17 +213,18 @@ const mapper = (mapfn, opt) => {
       opt.input.schema.validate(req.body);
 
     // Forward authorization header field to mapfn and log
-    const o = pick(req.headers, 'authorization');
+    const auth = req.headers && req.headers.authorization ?
+      req.headers.authorization : undefined;
 
     // Map the input doc to a list of output docs
-    const odocs = yield mapfn(req.body, o);
+    const odocs = yield mapfn(req.body, auth);
 
     // Log the input doc and output docs
     const ids = yield log(
       opt.input.type, req.body, opt.input.key, opt.input.time, idb,
       opt.output.type, odocs, opt.output.key, opt.output.time, odb,
       opt.sink.host, opt.sink.partition, opt.sink.post,
-      o);
+      auth);
 
     // Return the input and output doc locations
     return {

--- a/lib/utils/dataflow/src/test/test.js
+++ b/lib/utils/dataflow/src/test/test.js
@@ -46,7 +46,7 @@ describe('abacus-dataflow', () => {
 
       // Define a test map transform that computes the sum of a pair of
       // numbers
-      const sum = function *(doc, opt) {
+      const sum = function *(doc, auth) {
         return [{
           val: doc.x + doc.y
         }];


### PR DESCRIPTION
Based on review comments - change opt object argument into a simple string
argument named auth, move auth optional argument to the end of the argument
list, and forward and use authorization field when retrieving price details
from account stub.

See tracker [#101701306] and github issue #35.
