### PR TITLE
Retrieve resource configuration asynchronously

### DIFF
--- a/lib/stubs/provisioning/src/index.js
+++ b/lib/stubs/provisioning/src/index.js
@@ -124,7 +124,7 @@ routes.get(
     // This is a stub here so we only validate the resource_id. A complete
     // implementation of this service should validate all the other
     // parameters
-    if(!config(req.params.resource_id, parseInt(req.params.time)))
+    if(!(yield config(req.params.resource_id, parseInt(req.params.time))))
       return {
         status: 404
       };

--- a/lib/stubs/provisioning/src/test/test.js
+++ b/lib/stubs/provisioning/src/test/test.js
@@ -29,6 +29,11 @@ describe('abacus-provisioning-stub', () => {
       // Listen on an ephemeral port
       const server = app.listen(0);
 
+      let cbs = 0;
+      const cb = () => {
+        if(++cbs === 2) done();
+      };
+
       // Validate a valid provisioned resource instance
       const valid = {
         region: 'us',
@@ -40,6 +45,7 @@ describe('abacus-provisioning-stub', () => {
         resource_instance_id: '0b39fa70-a65f-4183-bae8-385633ca5c87',
         time: 1420070400000
       };
+
       request.get(
         'http://localhost::p/v1/provisioning/regions/:region/orgs/:org_id/' +
         'spaces/:space_id/consumers/:consumer_id/resources/:resource_id/' +
@@ -49,7 +55,7 @@ describe('abacus-provisioning-stub', () => {
           expect(err).to.equal(undefined);
           expect(val.statusCode).to.equal(200);
           expect(val.body).to.deep.equal(valid);
-          done();
+          cb();
         });
 
       // Reject an invalid provisioned resource instance, this one uses
@@ -64,15 +70,16 @@ describe('abacus-provisioning-stub', () => {
         resource_instance_id: '0b39fa70-a65f-4183-bae8-385633ca5c87',
         time: 1420070400000
       };
+
       request.get(
         'http://localhost::p/v1/provisioning/regions/:region/orgs/:org_id/' +
         'spaces/:space_id/consumers/:consumer_id/resources/:resource_id/' +
         'plans/:plan_id/instances/:resource_instance_id/:time', extend({
           p: server.address().port
         }, invalid), (err, val) => {
-          expect(err).to.not.equal(undefined);
-          expect(err.statusCode).to.equal(404);
-          done();
+          expect(err).to.equal(undefined);
+          expect(val.statusCode).to.equal(404);
+          cb();
         });
     });
 


### PR DESCRIPTION
Respond to requests only after getting and validating resource configurations.

Fixes github issue #79 and tracker [#105376594].
