### PR TITLE
Secure provisioning stub REST endpoints using OAuth bearer token

### DIFF
--- a/lib/stubs/provisioning/manifest.yml
+++ b/lib/stubs/provisioning/manifest.yml
@@ -5,4 +5,7 @@ applications:
   instances: 2
   memory: 512M
   disk_quota: 512M
-
+  env:
+    SECURED: false
+    JWTKEY: undefined
+    JWTALGO: undefined

--- a/lib/stubs/provisioning/package.json
+++ b/lib/stubs/provisioning/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "babel-runtime": "^5.8.19",
+    "abacus-cfoauth": "file:../../utils/cfoauth",
     "abacus-debug": "file:../../utils/debug",
     "abacus-router": "file:../../utils/router",
     "abacus-urienv": "file:../../utils/urienv",

--- a/lib/stubs/provisioning/src/index.js
+++ b/lib/stubs/provisioning/src/index.js
@@ -7,6 +7,7 @@
 const _ = require('underscore');
 const webapp = require('abacus-webapp');
 const router = require('abacus-router');
+const oauth = require('abacus-cfoauth');
 const schemas = require('abacus-usage-schemas');
 const urienv = require('abacus-urienv');
 const dbclient = require('abacus-dbclient');
@@ -23,6 +24,9 @@ const extend = _.extend;
 
 // Setup debug log
 const debug = require('abacus-debug')('abacus-provisioning-stub');
+
+// Secure the routes or not
+const secured = () => process.env.SECURED === 'true' ? true : false;
 
 const uris = urienv({
   couchdb: 5984
@@ -175,8 +179,15 @@ routes.post(
 // Create a provisisioning stub app
 const provisioning = () => {
   const app = webapp();
+
+  // Secure provisioning and batch routes using an OAuth
+  // bearer access token
+  if (secured())
+    app.use(/^\/v1\/provisioning|^\/batch$/,
+      oauth.validator(process.env.JWTKEY, process.env.JWTALGO));
+
   app.use(routes);
-  app.use(router.batch(routes));
+  app.use(router.batch(app));
   return app;
 };
 

--- a/lib/stubs/provisioning/src/test/test.js
+++ b/lib/stubs/provisioning/src/test/test.js
@@ -5,11 +5,15 @@
 
 const _ = require('underscore');
 const request = require('abacus-request');
+const batch = require('abacus-batch');
 const cluster = require('abacus-cluster');
+const oauth = require('abacus-cfoauth');
 const schemas = require('abacus-usage-schemas');
 
 const extend = _.extend;
 const map = _.map;
+
+const brequest = batch(request);
 
 // Configure test db URL prefix
 process.env.COUCHDB = process.env.COUCHDB || 'test';
@@ -18,69 +22,89 @@ process.env.COUCHDB = process.env.COUCHDB || 'test';
 require.cache[require.resolve('abacus-cluster')].exports =
   extend((app) => app, cluster);
 
+// Mock the oauth module with a spy
+const oauthspy = spy((req, res, next) => next());
+const oauthmock = extend({}, oauth, {
+  validator: () => oauthspy
+});
+require.cache[require.resolve('abacus-cfoauth')].exports = oauthmock;
+
 const provisioning = require('..');
 
 describe('abacus-provisioning-stub', () => {
   it('returns resource instance info by ' +
     'region/org/space/app/resource/plan/instance', (done) => {
-      // Create a test provisioning app
-      const app = provisioning();
+      const verify = (secured, done) => {
+        process.env.SECURED = secured ? 'true' : 'false';
+        oauthspy.reset();
 
-      // Listen on an ephemeral port
-      const server = app.listen(0);
+        // Create a test provisioning app
+        const app = provisioning();
 
-      let cbs = 0;
-      const cb = () => {
-        if(++cbs === 2) done();
+        // Listen on an ephemeral port
+        const server = app.listen(0);
+
+        let cbs = 0;
+        const cb = () => {
+          if(++cbs === 2) {
+            // Check oauth validator spy
+            expect(oauthspy.callCount).to.equal(secured ? 3 : 0);
+
+            done();
+          }
+        };
+
+        // Validate a valid provisioned resource instance
+        const valid = {
+          region: 'us',
+          org_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
+          space_id: 'aaeae239-f3f8-483c-9dd0-de5d41c38b6a',
+          consumer_id: 'bbeae239-f3f8-483c-9dd0-de6781c38bab',
+          resource_id: 'object-storage',
+          plan_id: 'basic',
+          resource_instance_id: '0b39fa70-a65f-4183-bae8-385633ca5c87',
+          time: 1420070400000
+        };
+
+        request.get(
+          'http://localhost::p/v1/provisioning/regions/:region/orgs/:org_id/' +
+          'spaces/:space_id/consumers/:consumer_id/resources/:resource_id/' +
+          'plans/:plan_id/instances/:resource_instance_id/:time', extend({
+            p: server.address().port
+          }, valid), (err, val) => {
+            expect(err).to.equal(undefined);
+            expect(val.statusCode).to.equal(200);
+            expect(val.body).to.deep.equal(valid);
+            cb();
+          });
+
+        // Reject an invalid provisioned resource instance, this one uses
+        // an invalid resource_id
+        const invalid = {
+          region: 'us',
+          org_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
+          space_id: 'aaeae239-f3f8-483c-9dd0-de5d41c38b6a',
+          consumer_id: 'bbeae239-f3f8-483c-9dd0-de6781c38bab',
+          resource_id: 'invalid-resource',
+          plan_id: 'basic',
+          resource_instance_id: '0b39fa70-a65f-4183-bae8-385633ca5c87',
+          time: 1420070400000
+        };
+
+        brequest.get(
+          'http://localhost::p/v1/provisioning/regions/:region/orgs/:org_id/' +
+          'spaces/:space_id/consumers/:consumer_id/resources/:resource_id/' +
+          'plans/:plan_id/instances/:resource_instance_id/:time', extend({
+            p: server.address().port
+          }, invalid), (err, val) => {
+            expect(err).to.equal(undefined);
+            expect(val.statusCode).to.equal(404);
+            cb();
+          });
       };
 
-      // Validate a valid provisioned resource instance
-      const valid = {
-        region: 'us',
-        org_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
-        space_id: 'aaeae239-f3f8-483c-9dd0-de5d41c38b6a',
-        consumer_id: 'bbeae239-f3f8-483c-9dd0-de6781c38bab',
-        resource_id: 'object-storage',
-        plan_id: 'basic',
-        resource_instance_id: '0b39fa70-a65f-4183-bae8-385633ca5c87',
-        time: 1420070400000
-      };
-
-      request.get(
-        'http://localhost::p/v1/provisioning/regions/:region/orgs/:org_id/' +
-        'spaces/:space_id/consumers/:consumer_id/resources/:resource_id/' +
-        'plans/:plan_id/instances/:resource_instance_id/:time', extend({
-          p: server.address().port
-        }, valid), (err, val) => {
-          expect(err).to.equal(undefined);
-          expect(val.statusCode).to.equal(200);
-          expect(val.body).to.deep.equal(valid);
-          cb();
-        });
-
-      // Reject an invalid provisioned resource instance, this one uses
-      // an invalid resource_id
-      const invalid = {
-        region: 'us',
-        org_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
-        space_id: 'aaeae239-f3f8-483c-9dd0-de5d41c38b6a',
-        consumer_id: 'bbeae239-f3f8-483c-9dd0-de6781c38bab',
-        resource_id: 'invalid-resource',
-        plan_id: 'basic',
-        resource_instance_id: '0b39fa70-a65f-4183-bae8-385633ca5c87',
-        time: 1420070400000
-      };
-
-      request.get(
-        'http://localhost::p/v1/provisioning/regions/:region/orgs/:org_id/' +
-        'spaces/:space_id/consumers/:consumer_id/resources/:resource_id/' +
-        'plans/:plan_id/instances/:resource_instance_id/:time', extend({
-          p: server.address().port
-        }, invalid), (err, val) => {
-          expect(err).to.equal(undefined);
-          expect(val.statusCode).to.equal(404);
-          cb();
-        });
+      // Verify using an unsecured server and then verify using a secured server
+      verify(false, () => verify(true, done));
     });
 
   it('returns available resource configs', (done) => {


### PR DESCRIPTION
Define SECURED environment variable to enable authenticating incoming requests.

Define JWTKEY and JWTALGO environment variables to configure JWT-JWS based
bearer access token validation.

Add OAuth validator middleware to /v1/provisioning and /batch routes and update
unit tests.

See tracker [#101701306] and github issue #35.
