### PR TITLE
Use OAuth bearer access token to retrieve resource configuration

### DIFF
--- a/lib/aggregation/accumulator/src/index.js
+++ b/lib/aggregation/accumulator/src/index.js
@@ -94,7 +94,7 @@ const accum = (au, metric) => {
 };
 
 // Accumulate usage and return new accumulated value
-const accumulate = function *(a, u) {
+const accumulate = function *(a, u, auth) {
   // Use previous accumulated value if any
   const umerge = omit(u, 'id', 'metrics', 'metered_usage', 'measured_usage');
   const amerge = !a || !a.start ? extend({
@@ -104,7 +104,7 @@ const accumulate = function *(a, u) {
   const oldend = dateUTCNumbify(a.end) || 0;
 
   // Retrieve the configured metrics for the resource
-  const conf = yield config(u.resource_id, u.end);
+  const conf = yield config(u.resource_id, u.end, auth);
 
   // Calculate new accumulated usage
   const newa = extend({}, amerge, {
@@ -230,7 +230,8 @@ const updateAccumulatedUsage =
 
       // Accumulate usage, starting with the initial one
       const rres = yield treduce(calls, function *(rres, call) {
-        const newa = yield accumulate(rres.newa, call[0].u, call[0].u);
+        const newa = yield accumulate(rres.newa, call[0].u,
+          call[0].auth);
         return {
           newa: newa,
           ares: rres.ares.concat([[undefined, omit(newa, 'dbrev')]])
@@ -252,7 +253,7 @@ const updateAccumulatedUsage =
     }
   }, function *(args) {
     // Group calls by accumulated usage id
-    return args[0].aid;
+    return [args[0].aid, args[0].auth ? args[0].auth : ''].join('-');
   })));
 
 // Accumulate the given usage
@@ -272,7 +273,7 @@ const accumulateUsage = function *(u, auth) {
 
   // Update accumulated usage
   const newa = yield updateAccumulatedUsage({
-    u: u, aid: aid, alogid: alogid, ulogid: ulogid });
+    u: u, aid: aid, alogid: alogid, ulogid: ulogid, auth: auth });
 
   // Post the new accumulated usage to the target aggregator partition
   const alogdoc = extend(dbclient.undbify(newa), {

--- a/lib/aggregation/aggregator/src/index.js
+++ b/lib/aggregation/aggregator/src/index.js
@@ -219,7 +219,7 @@ const aggrfn = (metrics, metric) => {
 };
 
 // Aggregate usage and return new aggregated usage
-const aggregate = function *(a, u, n, o) {
+const aggregate = function *(a, u, n, o, auth) {
   // Deep clone and revive the org aggregated usage object behavior
   const newa = reviveOrg(JSON.parse(JSON.stringify(a)));
 
@@ -227,7 +227,7 @@ const aggregate = function *(a, u, n, o) {
   yield tmap(u.accumulated_usage, function *(ua) {
 
     // Find the aggregate function for the given metric
-    const conf = yield config(u.resource_id, u.end);
+    const conf = yield config(u.resource_id, u.end, auth);
 
     const afn = aggrfn(conf.metrics, ua.metric);
     const aggr = (a, qty) => {
@@ -330,7 +330,7 @@ const updateAggregatedUsage =
         const newa = yield aggregate(extend(rres.newa, {
           start: call[0].u.end,
           end: call[0].u.end
-        }), call[0].u, newend, oldend);
+        }), call[0].u, newend, oldend, call[0].auth);
         return {
           newa: newa,
           ares: rres.ares.concat([[undefined, omit(newa, 'dbrev')]])
@@ -353,7 +353,7 @@ const updateAggregatedUsage =
     }
   }, function *(args) {
     // Group calls by aggregated usage id
-    return args[0].aid;
+    return [args[0].aid, args[0].auth ? args[0].auth : ''].join('-');
   })));
 
 // Aggregate the given accumulated usage
@@ -368,7 +368,8 @@ const aggregateUsage = function *(u, auth) {
     u: u,
     aid: aid,
     alogid: alogid,
-    uid: uid
+    uid: uid,
+    auth: auth
   });
 
   // Log the new aggregated usage

--- a/lib/aggregation/rate/src/index.js
+++ b/lib/aggregation/rate/src/index.js
@@ -109,7 +109,7 @@ const rate = function *(r, u, pc, auth) {
   const rateResource = function *(rs) {
 
     // Find the metrics configured for the given resource
-    const conf = yield config(rs.resource_id, u.end);
+    const conf = yield config(rs.resource_id, u.end, auth);
 
     // Compute the cost of each metric under the resource plans
     return extend({}, rs, {

--- a/lib/aggregation/reporting/src/index.js
+++ b/lib/aggregation/reporting/src/index.js
@@ -76,12 +76,12 @@ const sumCharges = (a, m) => {
 };
 
 // Compute the charges for the given rated usage
-const chargeUsage = function *(t, r) {
+const chargeUsage = function *(t, r, auth) {
   // Charge the rated usage under a resource
   const chargeResource = function *(rs) {
 
     // Find the metrics configured for the given resource
-    const conf = yield config(rs.resource_id, r.end);
+    const conf = yield config(rs.resource_id, r.end, auth);
 
     // Compute the charge of each metric under the resource's plans
     const plans = map(rs.plans, (p) => {
@@ -179,12 +179,12 @@ const chargeUsage = function *(t, r) {
 };
 
 // Compute usage summaries for the given aggregated usage
-const summarizeUsage = function *(t, a) {
+const summarizeUsage = function *(t, a, auth) {
   // Summarize the aggregated usage under a resource
   const summarizeResource = function *(rs) {
 
     // Find the metrics configured for the given resource
-    const conf = yield config(rs.resource_id, a.end);
+    const conf = yield config(rs.resource_id, a.end, auth);
 
     // Summarize a metric
     const summarizeMetric = (m) => {
@@ -231,7 +231,7 @@ const summarizeUsage = function *(t, a) {
 };
 
 // Return the usage for an org in a given time period
-const orgUsage = function *(orgid, time) {
+const orgUsage = function *(orgid, time, auth) {
   // Compute the query range
   const t = time || Date.now();
   const d = new Date(t);
@@ -257,14 +257,15 @@ const orgUsage = function *(orgid, time) {
   }
 
   debug('Found rated usage %o', doc.rows[0].doc);
-  return yield chargeUsage(t, yield summarizeUsage(t, doc.rows[0].doc));
+  return yield chargeUsage(t,
+    yield summarizeUsage(t, doc.rows[0].doc, auth), auth);
 };
 
 // Return the usage for a list of orgs in a given time period
-const orgsUsage = function *(orgids, time) {
+const orgsUsage = function *(orgids, time, auth) {
   const t = time || Date.now();
   return yield tmap(orgids, function *(orgid) {
-    return yield orgUsage(orgid, t);
+    return yield orgUsage(orgid, t, auth);
   });
 };
 
@@ -309,7 +310,7 @@ const graphSchema = new GraphQLSchema({
         },
         resolve: (root, args) => {
           return yieldable.promise(orgUsage)(
-              args.organization_id, args.time);
+              args.organization_id, args.time, args.authorization);
         }
       },
       organizations: {
@@ -330,7 +331,7 @@ const graphSchema = new GraphQLSchema({
         },
         resolve: (root, args) => {
           return yieldable.promise(orgsUsage)(
-              args.organization_ids, args.time);
+              args.organization_ids, args.time, args.authorization);
         }
       },
       account: {
@@ -369,9 +370,12 @@ const retrieveUsage = function *(req) {
   debug('Retrieving rated usage for organization %s on %s',
     req.params.organization_id, req.params.time);
 
+  const auth = req.headers && req.headers.authorization ?
+    req.headers.authorization : undefined;
+
   // Retrieve and return the rated usage for the given org and time
   const doc = yield orgUsage(req.params.organization_id,
-    req.params.time ? parseInt(req.params.time) : undefined);
+    req.params.time ? parseInt(req.params.time) : undefined, auth);
 
   return {
     body: omit(dbclient.undbify(doc),

--- a/lib/config/resource/src/index.js
+++ b/lib/config/resource/src/index.js
@@ -93,7 +93,7 @@ const cached = (k) => {
 };
 
 // Retrieve the configuration for the specified resource and time
-const config = (rid, time, cb) => {
+const config = (rid, time, auth, cb) => {
   // Round time to a 10 min boundary
   const t = Math.floor(time / 600000) * 600000;
   const k = [rid, t].join('/');
@@ -112,12 +112,15 @@ const config = (rid, time, cb) => {
       return unlock(
         cb(undefined, cache(k, compile(require('./test/test-resource')))));
 
+    // Forward authorization header field to provisioning
+    const o = auth ? { headers: { authorization: auth } } : {};
+
     // Get the requested resource config from the config service
     return brequest.get(uris.provisioning +
-      '/v1/provisioning/resources/:resource_id/config/:time', {
+      '/v1/provisioning/resources/:resource_id/config/:time', extend(o, {
         resource_id: rid,
         time: t
-      }, (err, val) => {
+      }), (err, val) => {
         if(err)
           return cb(err);
         

--- a/lib/config/resource/src/test/test.js
+++ b/lib/config/resource/src/test/test.js
@@ -14,13 +14,13 @@ describe('abacus-resource-config', () => {
 
     // Retrieve a resource config
     const t = 1420070400000;
-    config('test-resource', t, (err, val) => {
+    config('test-resource', t, undefined, (err, val) => {
       expect(err).to.equal(undefined);
       expect(val.source).to.deep.equal(require('./test-resource.js'));
       cb();
     })
     // Retrieve it again, this time it should be returned from the cache
-    config('test-resource', t, (err, val) => {
+    config('test-resource', t, undefined, (err, val) => {
       expect(err).to.equal(undefined);
       expect(val.source).to.deep.equal(require('./test-resource.js'));
       cb();

--- a/lib/metering/meter/src/index.js
+++ b/lib/metering/meter/src/index.js
@@ -53,7 +53,7 @@ const meterUsage = function *(udoc, auth) {
   });
 
   // Retrieve the configured resource metrics
-  const conf = yield config(udoc.resource_id, udoc.end);
+  const conf = yield config(udoc.resource_id, udoc.end, auth);
 
   // Apply the configured meter functions to the measured usage to
   // produce metered usage


### PR DESCRIPTION
Add OAuth bearer access token as a request header field when accessing
resource configuration.

See tracker [#101701306] and github issue #35.
