### PR TITLE
Enable Performance Test to run with secured and unsecured Abacus

### DIFF
--- a/test/perf/package.json
+++ b/test/perf/package.json
@@ -35,6 +35,7 @@
     "abacus-request": "file:../../lib/utils/request",
     "abacus-throttle": "file:../../lib/utils/throttle",
     "abacus-debug": "file:../../lib/utils/debug",
+    "jsonwebtoken": "^5.0.5",
     "underscore": "^1.8.3",
     "commander": "2.8.1"
   },


### PR DESCRIPTION
Add OAuth bearer access token to request header field for submitting usage and
for retrieving usage report.

See tracker [#101701306] and github issue #35.
