### PR TITLE
Add debug logs to authentication middleware

### DIFF
--- a/lib/utils/cfoauth/src/index.js
+++ b/lib/utils/cfoauth/src/index.js
@@ -16,6 +16,7 @@ const retry = require('abacus-retry');
 const extend = _.extend;
 
 const debug = require('abacus-debug')('abacus-oauth');
+const edebug = require('abacus-debug')('e-abacus-oauth');
 
 const get = retry(request.get);
 
@@ -127,24 +128,42 @@ const validate = (token, secret, algorithm, cb) => {
 // Return an Express middleware that verifies an oauth bearer access token
 const validator = (secret, algorithm) => {
   return (req, res, next) => {
-    // Check authoriation header field for a bearer access token
+    debug('Authenticating request using OAuth bearer access token');
+
+    // Check authorization header field for a bearer access token
     // then verfify the access token using jwt
-    if (req.headers.authorization &&
-      /^bearer /i.test(req.headers.authorization))
+    if (req.headers && req.headers.authorization &&
+      /^bearer /i.test(req.headers.authorization)) {
+      debug('Validating OAuth bearer access token');
+
       validate(req.headers.authorization.replace(/^bearer /i, ''),
         secret, algorithm, (err, val) => {
-          if (err)
+          if (err) {
+            edebug('OAuth bearer access token validation failed, %s',
+              err.message);
+            debug('OAuth bearer access token validation failed, %s',
+              err.message);
+
             return res.status(401).header('WWW-Authenticate',
               'Bearer realm="cf",' +
               ' error="invalid_token",' +
               ' error_description="' + err.message + '"').end();
+          }
 
+          debug('Validated OAuth bearer access token');
           // has a valid token, so proceed to process the request
           return next();
         });
-    else
+    }
+    else {
+      edebug('Invalid OAuth bearer access token, %o',
+        req.headers ? req.headers.authorization : '');
+      debug('Invalid OAuth bearer access token, %o',
+        req.headers ? req.headers.authorization : '');
+
       return res.status(401).header('WWW-Authenticate',
         'Bearer realm="cf"').end();
+    }
   };
 };
 

--- a/lib/utils/cfoauth/src/test/test.js
+++ b/lib/utils/cfoauth/src/test/test.js
@@ -343,7 +343,7 @@ describe('Validate token', () => {
   it('Valid token - arguments', (done) => {
     // Sign known token using default algorithm (HS256)
     const signed = jwt.sign(decodedToken.payload, tokenSecret, {
-      expiresInMinutes: 720
+      expiresIn: 43200
     });
 
     // Test the validation
@@ -358,7 +358,7 @@ describe('Validate token', () => {
   it('Valid token - env property', (done) => {
     // Sign known token using default algorithm (HS256)
     const signed = jwt.sign(decodedToken.payload, tokenSecret, {
-      expiresInMinutes: 720
+      expiresIn: 43200
     });
 
     // Test the validation
@@ -373,7 +373,7 @@ describe('Validate token', () => {
   it('Invalid signature', (done) => {
     // Sign known token using default algorithm (HS256) and invalid secret
     const signed = jwt.sign(decodedToken.payload, invalidTokenSecret, {
-      expiresInMinutes: 720
+      expiresIn: 43200
     });
 
     // Test the validation
@@ -389,7 +389,7 @@ describe('Validate token', () => {
   it('Signing algorithm not specified', (done) => {
     // Sign known token using default algorithm (HS256) and invalid secret
     const signed = jwt.sign(decodedToken.payload, invalidTokenSecret, {
-      expiresInMinutes: 720
+      expiresIn: 43200
     });
 
     // Test the validation
@@ -494,7 +494,7 @@ describe('abacus-oauth', () => {
 
     // Sign a known token using default algorithm (HS256)
     const signed = jwt.sign(decodedToken.payload, tokenSecret, {
-      expiresInMinutes: 720
+      expiresIn: 43200
     });
 
     // Request the protected resource using a vaid oauth token


### PR DESCRIPTION
Add logs to validator function. Remove JWT warning -
jsonwebtoken: expiresInMinutes and expiresInSeconds is deprecated.
Use "expiresIn" expressed in seconds.

See tracker [#101701306] and github issue #35.
