### PR TITLE
Fix performance test to send independent usage records

### DIFF
--- a/bin/citest
+++ b/bin/citest
@@ -7,6 +7,6 @@
 # intergration test matrix, we would need 2197(= 13 * 13 * 13)
 # usage submissions to get above 90 percent regression coverage
 npm run itest -- -o 5 -i 5 -u 5  &&
-npm start && sleep 10s && npm run demo && npm run perf -- -o 1 -i 1 -u 1 && npm stop &&
+npm start && sleep 10s && npm run demo && npm run perf -- -o 12 -i 12 -u 12 && npm stop &&
 export SECURED=true JWTKEY=encode JWTALGO=HS256 &&
-npm start && sleep 10s && npm run perf -- -o 1 -i 1 -u 1 && npm stop
+npm start && sleep 10s && npm run perf -- -o 12 -i 12 -u 12 && npm stop

--- a/test/perf/src/test/test.js
+++ b/test/perf/src/test/test.js
@@ -269,7 +269,7 @@ describe('abacus-perf-test', () => {
       debug('Submitting org%d instance%d usage%d',
         o + 1, ri + 1, i + 1);
       brequest.post('http://localhost:9080/v1/metering/collected/usage',
-        extend(opt, { body: usageTemplate(o, ri, i) }), (err, val) => {
+        extend({}, opt, { body: usageTemplate(o, ri, i) }), (err, val) => {
           expect(err).to.equal(undefined);
           expect(val.statusCode).to.equal(201);
           debug('Completed submission org%d instance%d usage%d',
@@ -305,7 +305,7 @@ describe('abacus-perf-test', () => {
     let gets = 0;
     const get = (o, done) => {
       brequest.get('http://localhost:9088' + '/v1/metering/organizations' +
-        '/:organization_id/aggregated/usage/:time', extend(opt, {
+        '/:organization_id/aggregated/usage/:time', extend({}, opt, {
           organization_id: orgid(o),
           time: end + usage
         }), (err, val) => {


### PR DESCRIPTION
Clone the options object, before sending it as part of batch request.

Increase the performance test coverage to -o 12 -i 12 -u 12.

Fixes github issue #81.
