### PR TITLE
Set maximum listeners to unlimited for all EventEmitter instances

### DIFF
--- a/lib/utils/events/src/index.js
+++ b/lib/utils/events/src/index.js
@@ -16,6 +16,9 @@ const memoize = _.memoize;
 const first = _.first;
 const rest = _.rest;
 
+// Don't limit the number of listeners
+events.EventEmitter.defaultMaxListeners = 0;
+
 // Return an emitter, if a name is provided the emitter is shared
 const emitter = (name) => {
   if(name) return global.__shared_emitter(name);


### PR DESCRIPTION
EventEmitters print a warning if more than 10 listeners are added for
a particular event. This is a useful default which helps finding memory leaks.

Setting this value to unlimitted to avoid getting this warning when handling
more than 10 requests at a time. In the case of a batch request, we will not
see this warning till we handle more than 9 requests in a batch.

Fixes github issue #82.
