### PR TITLE
Scale back performance test to a minimum at Travis cibuild

### DIFF
--- a/bin/citest
+++ b/bin/citest
@@ -7,6 +7,6 @@
 # intergration test matrix, we would need 2197(= 13 * 13 * 13)
 # usage submissions to get above 90 percent regression coverage
 npm run itest -- -o 5 -i 5 -u 5  &&
-npm start && sleep 10s && npm run demo && npm run perf -- -o 12 -i 12 -u 12 && npm stop &&
+npm start && sleep 10s && npm run demo && npm run perf -- -o 1 -i 1 -u 1 && npm stop &&
 export SECURED=true JWTKEY=encode JWTALGO=HS256 &&
-npm start && sleep 10s && npm run perf -- -o 12 -i 12 -u 12 && npm stop
+npm start && sleep 10s && npm run perf -- -o 8 -i 8 -u 8 && npm stop


### PR DESCRIPTION
Avoid weird errors on node version 0.12.7 based builds.

Node version 0.10.40 does not suppress the warning: 'possible EventEmitter
memory leak detected. 11 listeners added. Use emitter.setMaxListeners() to
increase limit'.

See github issue #82.
