### PR TITLE
Implement scope based authorization to usage collector REST endpoints

### DIFF
--- a/lib/metering/collector/src/index.js
+++ b/lib/metering/collector/src/index.js
@@ -18,7 +18,9 @@ const schemas = require('abacus-usage-schemas');
 const dataflow = require('abacus-dataflow');
 const oauth = require('abacus-cfoauth');
 
+const map = _.map;
 const extend = _.extend;
+const uniq = _.uniq;
 
 const tmap = yieldable(transform.map);
 
@@ -35,6 +37,25 @@ const uris = urienv({
   provisioning: 9380,
   meter: 9081
 });
+
+// Return OAuth resource or admin scopes needed to write input docs
+const iwscope = (udoc) => secured() ? {
+  resource: map(uniq(map(udoc.usage, (u) => u.resource_id)),
+    (rid) => ['abacus.usage', rid, 'write'].join('.')),
+  system: ['abacus.usage.write']
+} : undefined;
+
+// Return OAuth resource or admin scopes needed to read input docs
+const irscope = (udoc) => secured() ? {
+  resource: map(uniq(map(udoc.usage, (u) => u.resource_id)),
+    (rid) => ['abacus.usage', rid, 'read'].join('.')),
+  system: ['abacus.usage.read']
+} : undefined;
+
+// Return OAuth resource or admin scopes needed to read output docs
+const orscope = (udoc) => secured() ? {
+  system: ['abacus.usage.read']
+} : undefined;
 
 // Return the keys and times of our docs
 const ikey = (udoc) => 'provider';
@@ -82,6 +103,8 @@ const collector = () => {
       post: '/v1/metering/collected/usage',
       get: '/v1/metering/collected/usage/t/:t/k/:k',
       dbname: 'abacus-collector-collected-usage',
+      wscope: iwscope,
+      rscope: irscope,
       key: ikey,
       time: itime
     },
@@ -89,6 +112,7 @@ const collector = () => {
       type: 'normalized_usage',
       get: '/v1/metering/normalized/usage/t/:t/k/:k',
       dbname: 'abacus-collector-normalized-usage',
+      rscope: orscope,
       key: okey,
       time: otime
     },

--- a/lib/metering/collector/src/test/test.js
+++ b/lib/metering/collector/src/test/test.js
@@ -31,9 +31,10 @@ const reqmock = extend({}, request, {
 require.cache[require.resolve('abacus-request')].exports = reqmock;
 
 // Mock the oauth module with a spy
-const oauthspy = spy((req, res, next) => next());
+let validatorspy, authorizespy;
 const oauthmock = extend({}, oauth, {
-  validator: () => oauthspy
+  validator: () => (req, res, next) => validatorspy(req, res, next),
+  authorize: (auth, escope) => authorizespy(auth, escope)
 });
 require.cache[require.resolve('abacus-cfoauth')].exports = oauthmock;
 
@@ -66,8 +67,8 @@ describe('abacus-usage-collector', () => {
         }]
       };
 
+      // Set the SECURED environment variable
       process.env.SECURED = secured ? 'true' : 'false';
-      oauthspy.reset();
 
       // Create a test collector app
       const app = collector();
@@ -110,6 +111,9 @@ describe('abacus-usage-collector', () => {
         check();
       };
 
+      validatorspy = spy((req, res, next) => next());
+      authorizespy = spy(function() {});
+
       // Post usage for a resource, expecting a 201 response
       request.post('http://localhost::p/v1/metering/collected/usage', {
         p: server.address().port,
@@ -118,8 +122,13 @@ describe('abacus-usage-collector', () => {
         expect(err).to.equal(undefined);
         expect(val.statusCode).to.equal(201);
 
-        // Check oauth validator spy
-        expect(oauthspy.callCount).to.equal(secured ? 1 : 0);
+        // Check oauth validator and authorize spy
+        expect(validatorspy.callCount).to.equal(secured ? 1 : 0);
+        expect(authorizespy.args[0][0]).to.equal(undefined);
+        expect(authorizespy.args[0][1]).to.deep.equal(secured ? {
+          resource: ['abacus.usage.test-resource.write'],
+          system: ['abacus.usage.write']
+        } : undefined);
 
         // Get usage, expecting what we posted
         brequest.get(val.headers.location, {}, (err, val) => {
@@ -127,8 +136,13 @@ describe('abacus-usage-collector', () => {
           expect(val.statusCode).to.equal(200);
           expect(omit(val.body, 'id')).to.deep.equal(measured);
 
-          // Check oauth validator spy
-          expect(oauthspy.callCount).to.equal(secured ? 3 : 0);
+          // Check oauth validator and authorize spy
+          expect(validatorspy.callCount).to.equal(secured ? 3 : 0);
+          expect(authorizespy.args[1][0]).to.equal(undefined);
+          expect(authorizespy.args[1][1]).to.deep.equal(secured ? {
+            resource: ['abacus.usage.test-resource.read'],
+            system: ['abacus.usage.read']
+          } : undefined);
 
           check();
         });


### PR DESCRIPTION
Authorize requests using input and output scopes specified at dataflow mapper.

See github issue #35 and tracker [#104195632].
