### PR TITLE
Fix usage collector to not process usage for an unknown resource

### DIFF
--- a/lib/metering/collector/src/index.js
+++ b/lib/metering/collector/src/index.js
@@ -28,6 +28,7 @@ const brequest = yieldable(retry(breaker(batch(request))));
 
 // Setup debug log
 const debug = require('abacus-debug')('abacus-usage-collector');
+const edebug = require('abacus-debug')('e-abacus-usage-collector');
 
 // Secure the routes or not
 const secured = () => process.env.SECURED === 'true' ? true : false;
@@ -72,7 +73,7 @@ const normalizeUsage = function *(udoc, auth) {
 
   // Validate the given region/org/space/consumer/resource/resource_instances
   yield tmap(udoc.usage, function *(u) {
-    return yield brequest.get(uris.provisioning +
+    const res = yield brequest.get(uris.provisioning +
       '/v1/provisioning/regions/:region/orgs/:organization_id/spaces/' +
       ':space_id/consumers/:consumer_id/resources/:resource_id/plans/' +
       ':plan_id/instances/:resource_instance_id/:time',
@@ -81,6 +82,16 @@ const normalizeUsage = function *(udoc, auth) {
         consumer_id: u.consumer ? u.consumer.consumer_id : 'ALL',
         time: u.end
       }));
+
+    // Validation failed. Unable to retrieve provisioning information
+    // for the given resource instance
+    if (res.statusCode !== 200) {
+      edebug('Unable to retrieve provisioning information, %o', res);
+      debug('Unable to retrieve provisioning information, %o', res);
+
+      // Throw response object as an exception to stop further processing
+      throw res;
+    }
   });
 
   // Return the individual usage docs


### PR DESCRIPTION
Usage collector should not process an usage when provision validation fails.

Related to github issue #84.
