### PR TITLE
Implement scope based authorization to usage meter REST endpoints

### DIFF
--- a/lib/metering/meter/src/index.js
+++ b/lib/metering/meter/src/index.js
@@ -30,6 +30,16 @@ const uris = urienv({
   accumulator: 9100
 });
 
+// Return OAuth admin scopes needed to write input docs
+const iwscope = (udoc) => secured() ? {
+  system: ['abacus.usage.write']
+} : undefined;
+
+// Return OAuth admin scopes needed to read input and output docs
+const rscope = (udoc) => secured() ? {
+  system: ['abacus.usage.read']
+} : undefined;
+
 // Return the keys and times of our docs
 const ikey = (udoc) => 'provider';
 const itime = (udoc) => seqid();
@@ -96,6 +106,8 @@ const meterapp = () => {
       post: '/v1/metering/normalized/usage',
       get: '/v1/metering/normalized/usage/t/:t/k/:k',
       dbname: 'abacus-meter-normalized-usage',
+      wscope: iwscope,
+      rscope: rscope,
       key: ikey,
       time: itime
     },
@@ -104,6 +116,7 @@ const meterapp = () => {
       get: '/v1/metering/metered/usage/t/:t' +
         '/k/:korganization_id/:kresource_instance_id',
       dbname: 'abacus-meter-metered-usage',
+      rscope: rscope,
       key: okey,
       time: otime
     },

--- a/lib/metering/meter/src/test/test.js
+++ b/lib/metering/meter/src/test/test.js
@@ -26,9 +26,10 @@ const reqmock = extend({}, request, {
 require.cache[require.resolve('abacus-request')].exports = reqmock;
 
 // Mock the oauth module with a spy
-const oauthspy = spy((req, res, next) => next());
+let validatorspy, authorizespy;
 const oauthmock = extend({}, oauth, {
-  validator: () => oauthspy
+  validator: () => (req, res, next) => validatorspy(req, res, next),
+  authorize: (auth, escope) => authorizespy(auth, escope)
 });
 require.cache[require.resolve('abacus-cfoauth')].exports = oauthmock;
 
@@ -74,8 +75,8 @@ describe('abacus-usage-meter', () => {
         }]
       };
 
+      // Set the SECURED environment variable
       process.env.SECURED = secured ? 'true' : 'false';
-      oauthspy.reset();
 
       // Create a test meter app
       const app = meterapp();
@@ -122,6 +123,9 @@ describe('abacus-usage-meter', () => {
         check();
       };
 
+      validatorspy = spy((req, res, next) => next());
+      authorizespy = spy(function() {});
+
       // Post normalized usage to the meter service
       request.post('http://localhost::p/v1/metering/normalized/usage', {
         p: server.address().port,
@@ -130,16 +134,24 @@ describe('abacus-usage-meter', () => {
         expect(err).to.equal(undefined);
         expect(val.statusCode).to.equal(201);
 
-        // Check oauth validator spy
-        expect(oauthspy.callCount).to.equal(secured ? 1 : 0);
+        // Check oauth validator and authorize spy
+        expect(validatorspy.callCount).to.equal(secured ? 1 : 0);
+        expect(authorizespy.args[0][0]).to.equal(undefined);
+        expect(authorizespy.args[0][1]).to.deep.equal(secured ? {
+          system: ['abacus.usage.write']
+        } : undefined);
 
         // Get metered usage, expecting what we posted
         request.get(val.headers.location, {}, (err, val) => {
           expect(err).to.equal(undefined);
           expect(val.statusCode).to.equal(200);
 
-          // Check oauth validator spy
-          expect(oauthspy.callCount).to.equal(secured ? 2 : 0);
+          // Check oauth validator and authorize spy
+          expect(validatorspy.callCount).to.equal(secured ? 2 : 0);
+          expect(authorizespy.args[1][0]).to.equal(undefined);
+          expect(authorizespy.args[1][1]).to.deep.equal(secured ? {
+            system: ['abacus.usage.read']
+          } : undefined);
 
           expect(omit(val.body, 'id')).to.deep.equal(usage);
 

--- a/test/perf/src/test/test.js
+++ b/test/perf/src/test/test.js
@@ -237,10 +237,12 @@ describe('abacus-perf-test', () => {
       jti: 'fa1b29fe-76a9-4c2d-903e-dddd0563a9e3',
       sub: 'object-storage',
       authorities: [
-        'abacus.usage.object-storage.write'
+        'abacus.usage.object-storage.write',
+        'abacus.usage.write'
       ],
       scope: [
-        'abacus.usage.object-storage.write'
+        'abacus.usage.object-storage.write',
+        'abacus.usage.write'
       ],
       client_id: 'object-storage',
       cid: 'object-storage',


### PR DESCRIPTION
Authorize requests using input and output scopes specified with dataflow mapper.

Update performance test to include system scope for now.

See github issue #35 and tracker [#104195632].
