### PR TITLE
Implement scope based authorization to accumulator REST endpoints

### DIFF
--- a/lib/aggregation/accumulator/src/index.js
+++ b/lib/aggregation/accumulator/src/index.js
@@ -39,6 +39,16 @@ const uris = urienv({
   aggregator: 9200
 });
 
+// Return OAuth admin scopes needed to write input docs
+const iwscope = (udoc) => secured() ? {
+  system: ['abacus.usage.write']
+} : undefined;
+
+// Return OAuth admin scopes needed to read input and output docs
+const rscope = (udoc) => secured() ? {
+  system: ['abacus.usage.read']
+} : undefined;
+
 // Return the keys and times of our docs
 const ikey = (udoc) => [
   udoc.organization_id,
@@ -192,6 +202,8 @@ const accumulator = () => {
       get: '/v1/metering/metered/usage/k/:korganization_id' +
             '/:kresource_instance_id/:kplan_id/t/:tend/:tstart',
       dbname: 'abacus-accumulator-metered-usage',
+      wscope: iwscope,
+      rscope: rscope,
       key: ikey,
       time: itime
     },
@@ -200,6 +212,7 @@ const accumulator = () => {
       get: '/v1/metering/accumulated/usage/k/:korganization_id' +
         '/:kresource_instance_id/:kplan_id/t/:tend/:tseq',
       dbname: 'abacus-accumulator-accumulated-usage',
+      rscope: rscope,
       key: okey,
       time: otime,
       group: ogroup

--- a/lib/aggregation/accumulator/src/test/test.js
+++ b/lib/aggregation/accumulator/src/test/test.js
@@ -36,9 +36,10 @@ const reqmock = extend({}, request, {
 require.cache[require.resolve('abacus-request')].exports = reqmock;
 
 // Mock the oauth module with a spy
-const oauthspy = spy((req, res, next) => next());
+let validatorspy, authorizespy;
 const oauthmock = extend({}, oauth, {
-  validator: () => oauthspy
+  validator: () => (req, res, next) => validatorspy(req, res, next),
+  authorize: (auth, escope) => authorizespy(auth, escope)
 });
 require.cache[require.resolve('abacus-cfoauth')].exports = oauthmock;
 
@@ -413,6 +414,10 @@ describe('abacus-usage-accumulator', () => {
       }]]);
     };
 
+    // Initialize oauth spies
+    validatorspy = spy((req, res, next) => next());
+    authorizespy = spy(function() {});
+
     // Post usage to the accumulator
     const post = () => {
       transform.reduce(usage, (a, u, i, l, cb) =>
@@ -482,14 +487,18 @@ describe('abacus-usage-accumulator', () => {
     };
 
     const verify = (secured, done) => {
+      // Set the SECURED environment variable
       process.env.SECURED = secured ? 'true' : 'false';
-      oauthspy.reset();
 
       // Create a test accumulator app
       const app = accumulator();
 
       // Listen on an ephemeral port
       const server = app.listen(0);
+
+      // Initialize oauth spies
+      validatorspy = spy((req, res, next) => next());
+      authorizespy = spy(function() {});
 
       // Post usage for a resource, expecting a 201 response
       request.post('http://localhost::p/v1/metering/metered/usage', {
@@ -499,16 +508,24 @@ describe('abacus-usage-accumulator', () => {
         expect(err).to.equal(undefined);
         expect(val.statusCode).to.equal(201);
 
-        // Check oauth validator spy
-        expect(oauthspy.callCount).to.equal(secured ? 1 : 0);
+        // Check oauth validator and authorize spy
+        expect(validatorspy.callCount).to.equal(secured ? 1 : 0);
+        expect(authorizespy.args[0][0]).to.equal(undefined);
+        expect(authorizespy.args[0][1]).to.deep.equal(secured ? {
+          system: ['abacus.usage.write']
+        } : undefined);
 
         // Get usage, expecting what we posted
         brequest.get(val.headers.location, {}, (err, val) => {
           expect(err).to.equal(undefined);
           expect(val.statusCode).to.equal(200);
 
-          // Check oauth validator spy
-          expect(oauthspy.callCount).to.equal(secured ? 3 : 0);
+          // Check oauth validator and authorize spy
+          expect(validatorspy.callCount).to.equal(secured ? 3 : 0);
+          expect(authorizespy.args[1][0]).to.equal(undefined);
+          expect(authorizespy.args[1][1]).to.deep.equal(secured ? {
+            system: ['abacus.usage.read']
+          } : undefined);
 
           done();
         });


### PR DESCRIPTION
Authorize requests using input and output scopes specified with dataflow mapper.

See github issue #35 and tracker [#104195632].
