### PR TITLE
Implement scope based authorization to aggregator REST endpoints

### DIFF
--- a/lib/aggregation/aggregator/src/index.js
+++ b/lib/aggregation/aggregator/src/index.js
@@ -39,6 +39,16 @@ const uris = urienv({
   rating: 9410
 });
 
+// Return OAuth system scopes needed to write input docs
+const iwscope = (udoc) => secured() ? {
+  system: ['abacus.usage.write']
+} : undefined;
+
+// Return OAuth system scopes needed to read input and output docs
+const rscope = (udoc) => secured() ? {
+  system: ['abacus.usage.read']
+} : undefined;
+
 // Return the keys and times of our docs
 const ikey = (udoc) => [
   udoc.organization_id].join('/')
@@ -317,6 +327,8 @@ const aggregator = () => {
       get: '/v1/metering/accumulated/usage/k/:korganization_id' +
         '/t/:tend/:tseq',
       dbname: 'abacus-aggregator-accumulated-usage',
+      wscope: iwscope,
+      rscope: rscope,
       key: ikey,
       time: itime
     },
@@ -325,6 +337,7 @@ const aggregator = () => {
       get: '/v1/metering/aggregated/usage/k/:korganization_id' +
         '/t/:tend/:tseq',
       dbname: 'abacus-aggregator-aggregated-usage',
+      rscope: rscope,
       key: okey,
       time: otime,
       group: ogroup

--- a/lib/aggregation/aggregator/src/test/test.js
+++ b/lib/aggregation/aggregator/src/test/test.js
@@ -36,9 +36,10 @@ const reqmock = extend({}, request, {
 require.cache[require.resolve('abacus-request')].exports = reqmock;
 
 // Mock the oauth module with a spy
-const oauthspy = spy((req, res, next) => next());
+let validatorspy, authorizespy;
 const oauthmock = extend({}, oauth, {
-  validator: () => oauthspy
+  validator: () => (req, res, next) => validatorspy(req, res, next),
+  authorize: (auth, escope) => authorizespy(auth, escope)
 });
 require.cache[require.resolve('abacus-cfoauth')].exports = oauthmock;
 
@@ -1407,8 +1408,8 @@ describe('abacus-usage-aggregator', () => {
     }];
 
     const verify = (secured, done) => {
+      // Set the SECURED environment variable
       process.env.SECURED = secured ? 'true' : 'false';
-      oauthspy.reset();
 
       // Create a test aggregator app
       const app = aggregator();
@@ -1449,6 +1450,9 @@ describe('abacus-usage-aggregator', () => {
           check();
       };
 
+      // Initialize oauth validator spy
+      validatorspy = spy((req, res, next) => next());
+
       // Post accumulated usage to the aggregator
       const post = () => {
 
@@ -1459,6 +1463,10 @@ describe('abacus-usage-aggregator', () => {
               ['a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
                 secured ? 1 : 0].join('-')
           });
+
+          // Initialize oauth authorize spy
+          authorizespy = spy(function() {});
+
           request.post('http://localhost::p/v1/metering/accumulated/usage', {
             p: server.address().port,
             body: uval
@@ -1469,12 +1477,25 @@ describe('abacus-usage-aggregator', () => {
             expect(val.statusCode).to.equal(201);
             expect(val.headers.location).to.not.equal(undefined);
 
+            // Check oauth authorize spy
+            expect(authorizespy.args[0][0]).to.equal(undefined);
+            expect(authorizespy.args[0][1]).to.deep.equal(secured ? {
+              system: ['abacus.usage.write']
+            } : undefined);
+
             // Get accumulated usage back, expecting what we posted
             brequest.get(val.headers.location, {}, (err, val) => {
               expect(err).to.equal(undefined);
               expect(val.statusCode).to.equal(200);
 
               expect(omit(val.body, 'id')).to.deep.equal(uval);
+
+              // Check oauth authorize spy
+              expect(authorizespy.args[1][0]).to.equal(undefined);
+              expect(authorizespy.args[1][1]).to.deep.equal(secured ? {
+                system: ['abacus.usage.read']
+              } : undefined);
+
               cb();
             });
           });
@@ -1482,7 +1503,7 @@ describe('abacus-usage-aggregator', () => {
         }, undefined, () => {
 
           // Check oauth validator spy
-          expect(oauthspy.callCount).to.equal(secured ? 12 : 0);
+          expect(validatorspy.callCount).to.equal(secured ? 12 : 0);
 
           check();
         });


### PR DESCRIPTION
Authorize requests using input and output scopes specified with dataflow mapper.

See github issue #35 and tracker [#104195632].
