### PR TITLE
Implement scope based authorization at rating service REST endpoints

### DIFF
--- a/lib/aggregation/rate/src/index.js
+++ b/lib/aggregation/rate/src/index.js
@@ -45,6 +45,16 @@ const uris = urienv({
   account: 9381
 });
 
+// Return OAuth system scopes needed to write input docs
+const iwscope = (udoc) => secured() ? {
+  system: ['abacus.usage.write']
+} : undefined;
+
+// Return OAuth system scopes needed to read input and output docs
+const rscope = (udoc) => secured() ? {
+  system: ['abacus.usage.read']
+} : undefined;
+
 // Return the keys and times of our docs
 const ikey = (udoc) => [
   udoc.organization_id].join('/')
@@ -199,6 +209,8 @@ const rateapp = () => {
       get: '/v1/rating/aggregated/usage/k/:korganization_id' +
         '/t/:tend/:tseq',
       dbname: 'abacus-rating-aggregated-usage',
+      wscope: iwscope,
+      rscope: rscope,
       key: ikey,
       time: itime
     },
@@ -207,6 +219,7 @@ const rateapp = () => {
       get: '/v1/rating/rated/usage/k/:korganization_id' +
         '/t/:tend/:tseq',
       dbname: 'abacus-rating-rated-usage',
+      rscope: rscope,
       key: okey,
       time: otime
     },

--- a/lib/aggregation/rate/src/test/test.js
+++ b/lib/aggregation/rate/src/test/test.js
@@ -49,9 +49,10 @@ const dbclientmock = extend((part, uri, cons) => {
 require.cache[require.resolve('abacus-dbclient')].exports = dbclientmock;
 
 // Mock the oauth module with a spy
-const oauthspy = spy((req, res, next) => next());
+let validatorspy, authorizespy;
 const oauthmock = extend({}, oauth, {
-  validator: () => oauthspy
+  validator: () => (req, res, next) => validatorspy(req, res, next),
+  authorize: (auth, escope) => authorizespy(auth, escope)
 });
 require.cache[require.resolve('abacus-cfoauth')].exports = oauthmock;
 
@@ -1657,8 +1658,8 @@ describe('abacus-usage-rate', () => {
       }];
 
       const verify = (secured, done) => {
+        // Set the SECURED environment variable
         process.env.SECURED = secured ? 'true' : 'false';
-        oauthspy.reset();
 
         // Create a test rate app
         const app = rateapp();
@@ -1698,6 +1699,9 @@ describe('abacus-usage-rate', () => {
             check();
         };
 
+        // Initialize oauth validator spy
+        validatorspy = spy((req, res, next) => next());
+
         // Post aggregated usage to the rating service
         const post = (done) => {
 
@@ -1709,6 +1713,9 @@ describe('abacus-usage-rate', () => {
                   secured ? 1 : 0].join('-')
             });
 
+            // Initialize oauth authorize spy
+            authorizespy = spy(function() {});
+
             request.post('http://localhost::p/v1/rating/aggregated/usage', {
               p: server.address().port,
               body: uval
@@ -1719,12 +1726,25 @@ describe('abacus-usage-rate', () => {
               expect(val.statusCode).to.equal(201);
               expect(val.headers.location).to.not.equal(undefined);
 
+              // Check oauth authorize spy
+              expect(authorizespy.args[0][0]).to.equal(undefined);
+              expect(authorizespy.args[0][1]).to.deep.equal(secured ? {
+                system: ['abacus.usage.write']
+              } : undefined);
+
               // Get aggregated usage back, expecting what we posted
               brequest.get(val.headers.location, {}, (err, val) => {
                 expect(err).to.equal(undefined);
                 expect(val.statusCode).to.equal(200);
 
                 expect(omit(val.body, 'id')).to.deep.equal(uval);
+
+                // Check oauth authorize spy
+                expect(authorizespy.args[1][0]).to.equal(undefined);
+                expect(authorizespy.args[1][1]).to.deep.equal(secured ? {
+                  system: ['abacus.usage.read']
+                } : undefined);
+
                 cb();
               });
             });
@@ -1732,7 +1752,7 @@ describe('abacus-usage-rate', () => {
           }, undefined, () => {
 
             // Check oauth validator spy
-            expect(oauthspy.callCount).to.equal(
+            expect(validatorspy.callCount).to.equal(
               secured ? usage.length * 3 : 0);
 
             check();


### PR DESCRIPTION
Authorize requests using input and output scopes specified with dataflow mapper.

See github issue #35 and tracker [#104195632].
