### PR TITLE
Implement a reusable get OAuth bearer access token

### DIFF
--- a/lib/utils/cfoauth/src/index.js
+++ b/lib/utils/cfoauth/src/index.js
@@ -32,19 +32,22 @@ const tokenEndpoint = (apiHostName, cb) => {
     (error, response) => {
       if (error) {
         debug('Error oauth server %o', error);
-        cb(error);
+        return cb(error);
       }
+
       if (response.statusCode >= 400) {
         debug('%s - %s - has returned an error - response %d' +
           (response.body ? ' %o' : '%s'), response.request.method,
           response.request.path, response.statusCode,
           response.body ? response.body : '');
-        cb(new Error('Unable  to get oauth server information'));
+        return cb(new Error('Unable  to get oauth server information'));
       }
+
       debug('Retrieved %o', response.body.token_endpoint);
 
       // Return endpoint host
-      cb(null, url.parse(response.body.token_endpoint).hostname);
+      const u = url.parse(response.body.token_endpoint);
+      cb(null, u.hostname + (u.port ? ':' + u.port : ''));
     }
   );
 };
@@ -69,12 +72,13 @@ const newToken = (tokenEndpoint, clientId, secret, scopes, cb) => {
     }, (error, response) => {
       if (error) {
         debug('Error getting token : %o', error);
-        cb(error);
+        return cb(error);
       }
+
       if (response.statusCode >= 400) {
         debug('Error getting token, response %s, error %o', response.statusCode,
           response.body ? response.body : '');
-        cb(new Error('Unable to get OAUTH token'));
+        return cb(new Error('Unable to get OAUTH token'));
       }
 
       const tokenInfo = response.body;
@@ -226,6 +230,66 @@ const authorize = (auth, escope) => {
   debug('Authorized request with scope, %o', scope);
 };
 
+const cache = (authServer, id, secret, scopes) => {
+  // Store OAuth bearer access token for reuse
+  let token;
+
+  // Wrapper to get OAuth bearer access token
+  const wrapper = () => token ? 'Bearer ' + token.access_token : undefined;
+
+  // Get a OAuth bearer access token and then
+  // start a timer to refresh the token 2 minutes before expiration
+  wrapper.start = (cb) => {
+    let cbs = 0;
+    const done = (err) => {
+      // callback only one time
+      if (++cbs === 1) cb(err);
+    };
+
+    // Schedule a timer to refresh OAuth bearer access token
+    const refresh = (after) => {
+      debug('Scheduling refresh/retry getting OAuth bearer' +
+        ' access token after  %d msecs', after);
+      setTimeout(() => get(), after).unref();
+    };
+
+    // Report the error and retry after 2 minutes
+    const error = (err) => {
+      edebug('Error getting OAuth bearer access token, %o', err);
+      debug('Error getting OAuth bearer access token, %o', err);
+
+      // Retry after 2 minutes
+      refresh(120000);
+      done(err);
+    };
+
+    // Get OAuth bearer access token
+    const get = () => {
+      debug('Getting OAuth bearer access token');
+      // Get token endpoint from OAuth server
+      tokenEndpoint(authServer, (err, endpoint) => {
+        if (err) return error(err);
+
+        // Get token from the OAuth token endpoint
+        newToken(endpoint, id, secret, scopes, (err, t) => {
+          if (err) return error(err);
+
+          debug('Got OAuth bearer access token');
+          token = t;
+          refresh(Math.max(token.expires_in - 120000, 120000));
+          done();
+        });
+      });
+    };
+
+    // start to get OAuth bearer access token
+    get();
+  };
+
+  return wrapper;
+};
+
+module.exports.cache = cache;
 module.exports.tokenEndpoint = tokenEndpoint;
 module.exports.newToken = newToken;
 module.exports.decode = decode;

--- a/lib/utils/cfoauth/src/test/test.js
+++ b/lib/utils/cfoauth/src/test/test.js
@@ -655,4 +655,70 @@ describe('abacus-oauth', () => {
       }));
     }
   });
+
+  it('get OAuth bearer access token using cache', (done) => {
+    // Create a test Express application
+    const app = express();
+
+    // Add auth server REST endpoints
+    app.get('/v2/info', (req, res) => {
+      res.send({ token_endpoint: 'http://' + req.headers.host });
+    });
+
+    app.get('/oauth/token', (req, res) => {
+      if (req.query.scope === 'invalid') return res.status(400).end();
+
+      res.send({ access_token: 'AAA', token_type: 'bearer', expires_in: 1 });
+    });
+
+    // Listen on an ephemeral port
+    const server = app.listen(0);
+
+    let cbs = 0;
+    const cb = () => {
+      if (++cbs < 2) return;
+
+      // Now try a valid token and let it expire and refresh the token
+
+      // Setup a fake time
+      const clock = sinon.useFakeTimers(Date.now());
+
+      const token = oauth.cache('localhost:' + server.address().port,
+        'valid', 'secret', 'scopes');
+
+      token.start((err) => {
+        expect(err).to.equal(undefined);
+        expect(token()).to.equal('Bearer AAA');
+
+        // Let the token to be refreshed
+        clock.tick(1000 * 3600 * 2 + 1);
+        expect(token()).to.equal('Bearer AAA');
+
+        done();
+      });
+    };
+
+    // Unable to reach auth server
+    const invalidserver = oauth.cache('unknownauthhost',
+      'valid', 'secret', 'scopes');
+
+    invalidserver.start((err) => {
+      expect(err).to.deep.equal({ code: 'ENOTFOUND', errno: 'ENOTFOUND',
+        syscall: 'getaddrinfo', hostname: 'unknownauthhost' });
+      expect(invalidserver()).to.equal(undefined);
+
+      cb();
+    });
+
+    // Unable to get a token from auth server's token endpoint
+    const invalidtoken = oauth.cache('localhost:' + server.address().port,
+      'valid', 'secret', 'invalid');
+
+    invalidtoken.start((err) => {
+      expect(err).to.deep.equal(new Error('Unable to get OAUTH token'));
+      expect(invalidtoken()).to.equal(undefined);
+
+      cb();
+    });
+  });
 });


### PR DESCRIPTION
Based on cf-bridge oauth module, implement a function that maintains
a valid OAuth bearer access token by interacting with the auth server.

Fix few issues at cfoauth to avoid executing code after an error.

Update unit test to cover new scenarios.

See tracker [#101701306] and github issue #35.
