### PR TITLE
Use system access token when using a sink service at usage collector

### DIFF
--- a/lib/metering/collector/manifest.yml
+++ b/lib/metering/collector/manifest.yml
@@ -10,5 +10,8 @@ applications:
     PROVISIONING: abacus-provisioning-stub
     COUCHDB: abacus-dbserver
     SECURED: false
+    AUTHSERVER: undefined
+    CLIENTID: undefined
+    CLIENTSECRET: undefined
     JWTKEY: undefined
     JWTALGO: undefined

--- a/lib/metering/collector/src/index.js
+++ b/lib/metering/collector/src/index.js
@@ -33,27 +33,30 @@ const edebug = require('abacus-debug')('e-abacus-usage-collector');
 // Secure the routes or not
 const secured = () => process.env.SECURED === 'true' ? true : false;
 
+// OAuth bearer access token with Abacus system access scopes
+let systemToken;
+
 // Resolve service URIs
 const uris = urienv({
   provisioning: 9380,
   meter: 9081
 });
 
-// Return OAuth resource or admin scopes needed to write input docs
+// Return OAuth resource or system scopes needed to write input docs
 const iwscope = (udoc) => secured() ? {
   resource: map(uniq(map(udoc.usage, (u) => u.resource_id)),
     (rid) => ['abacus.usage', rid, 'write'].join('.')),
   system: ['abacus.usage.write']
 } : undefined;
 
-// Return OAuth resource or admin scopes needed to read input docs
+// Return OAuth resource or system scopes needed to read input docs
 const irscope = (udoc) => secured() ? {
   resource: map(uniq(map(udoc.usage, (u) => u.resource_id)),
     (rid) => ['abacus.usage', rid, 'read'].join('.')),
   system: ['abacus.usage.read']
 } : undefined;
 
-// Return OAuth resource or admin scopes needed to read output docs
+// Return OAuth resource or system scopes needed to read output docs
 const orscope = (udoc) => secured() ? {
   system: ['abacus.usage.read']
 } : undefined;
@@ -129,7 +132,8 @@ const collector = () => {
     },
     sink: {
       host: uris.meter,
-      post: '/v1/metering/normalized/usage'
+      post: '/v1/metering/normalized/usage',
+      authentication: systemToken
     }
   });
 
@@ -139,7 +143,17 @@ const collector = () => {
 };
 
 // Command line interface, create the collector app and listen
-const runCLI = () => collector().listen();
+const runCLI = () => {
+  // Cache and schedule the system token renewal
+  if (secured()) {
+    systemToken = oauth.cache(process.env.AUTHSERVER, process.env.CLIENTID,
+      process.env.CLIENTSECRET, 'abacus.usage.write abacus.usage.read');
+
+    systemToken.start();
+  }
+
+  collector().listen();
+}
 
 // Export our public functions
 module.exports = collector;

--- a/lib/metering/collector/src/test/test.js
+++ b/lib/metering/collector/src/test/test.js
@@ -31,10 +31,11 @@ const reqmock = extend({}, request, {
 require.cache[require.resolve('abacus-request')].exports = reqmock;
 
 // Mock the oauth module with a spy
-let validatorspy, authorizespy;
+let validatorspy, authorizespy, cachespy;
 const oauthmock = extend({}, oauth, {
   validator: () => (req, res, next) => validatorspy(req, res, next),
-  authorize: (auth, escope) => authorizespy(auth, escope)
+  authorize: (auth, escope) => authorizespy(auth, escope),
+  cache: () => cachespy()
 });
 require.cache[require.resolve('abacus-cfoauth')].exports = oauthmock;
 
@@ -69,6 +70,11 @@ describe('abacus-usage-collector', () => {
 
       // Set the SECURED environment variable
       process.env.SECURED = secured ? 'true' : 'false';
+      cachespy = spy(() => {
+        const f = () => undefined;
+        f.start = () => undefined;
+        return f;
+      });
 
       // Create a test collector app
       const app = collector();

--- a/lib/utils/cfoauth/src/index.js
+++ b/lib/utils/cfoauth/src/index.js
@@ -243,7 +243,7 @@ const cache = (authServer, id, secret, scopes) => {
     let cbs = 0;
     const done = (err) => {
       // callback only one time
-      if (++cbs === 1) cb(err);
+      if (++cbs === 1 && cb) cb(err);
     };
 
     // Schedule a timer to refresh OAuth bearer access token


### PR DESCRIPTION
Abacus processing pipeline should use its own system token to move
the processing to next step in the pipeline.

Make OAuth cache to take an optional callback function.

See tracker [#101701306] and github issue #35.
