### PR TITLE
Use system access token when using a sink service at usage meter

### DIFF
--- a/lib/metering/meter/manifest.yml
+++ b/lib/metering/meter/manifest.yml
@@ -10,5 +10,8 @@ applications:
     PROVISIONING: abacus-provisioning-stub
     COUCHDB: abacus-dbserver
     SECURED: false
+    AUTHSERVER: undefined
+    CLIENTID: undefined
+    CLIENTSECRET: undefined
     JWTKEY: undefined
     JWTALGO: undefined

--- a/lib/metering/meter/src/index.js
+++ b/lib/metering/meter/src/index.js
@@ -25,17 +25,20 @@ const debug = require('abacus-debug')('abacus-usage-meter');
 // Secure the routes or not
 const secured = () => process.env.SECURED === 'true' ? true : false;
 
+// OAuth bearer access token with Abacus system access scopes
+let systemToken;
+
 // Resolve service URIs
 const uris = urienv({
   accumulator: 9100
 });
 
-// Return OAuth admin scopes needed to write input docs
+// Return OAuth system scopes needed to write input docs
 const iwscope = (udoc) => secured() ? {
   system: ['abacus.usage.write']
 } : undefined;
 
-// Return OAuth admin scopes needed to read input and output docs
+// Return OAuth system scopes needed to read input and output docs
 const rscope = (udoc) => secured() ? {
   system: ['abacus.usage.read']
 } : undefined;
@@ -121,7 +124,8 @@ const meterapp = () => {
     sink : {
       host: uris.accumulator,
       post: '/v1/metering/metered/usage',
-      port: 9100
+      port: 9100,
+      authentication: systemToken
     }
   });
 
@@ -131,7 +135,17 @@ const meterapp = () => {
 };
 
 // Command line interface, create the meter  app and listen
-const runCLI = () => meterapp().listen();
+const runCLI = () => {
+  // Cache and schedule the system token renewal
+  if (secured()) {
+    systemToken = oauth.cache(process.env.AUTHSERVER, process.env.CLIENTID,
+      process.env.CLIENTSECRET, 'abacus.usage.write abacus.usage.read');
+
+    systemToken.start();
+  }
+
+  meterapp().listen();
+};
 
 // exports
 module.exports = meterapp;

--- a/lib/metering/meter/src/test/test.js
+++ b/lib/metering/meter/src/test/test.js
@@ -26,10 +26,11 @@ const reqmock = extend({}, request, {
 require.cache[require.resolve('abacus-request')].exports = reqmock;
 
 // Mock the oauth module with a spy
-let validatorspy, authorizespy;
+let validatorspy, authorizespy, cachespy;
 const oauthmock = extend({}, oauth, {
   validator: () => (req, res, next) => validatorspy(req, res, next),
-  authorize: (auth, escope) => authorizespy(auth, escope)
+  authorize: (auth, escope) => authorizespy(auth, escope),
+  cache: () => cachespy()
 });
 require.cache[require.resolve('abacus-cfoauth')].exports = oauthmock;
 
@@ -77,6 +78,12 @@ describe('abacus-usage-meter', () => {
 
       // Set the SECURED environment variable
       process.env.SECURED = secured ? 'true' : 'false';
+      cachespy = spy(() => {
+        const f = () => undefined;
+        f.start = () => undefined;
+        return f;
+      });
+
 
       // Create a test meter app
       const app = meterapp();


### PR DESCRIPTION
Abacus processing pipeline should use its own system token to move
the processing to next step in the pipeline.

Make OAuth cache to take an optional callback function.

See tracker [#101701306] and github issue #35.
