### PR TITLE
Use system access token when using sink service at usage accumulator

### DIFF
--- a/lib/aggregation/accumulator/manifest.yml
+++ b/lib/aggregation/accumulator/manifest.yml
@@ -6,9 +6,12 @@ applications:
   memory: 512M
   disk_quota: 512M
   env:
-    SECURED: false
-    JWTKEY: undefined
-    JWTALGO: undefined
     AGGREGATOR: abacus-usage-aggregator
     PROVISIONING: abacus-provisioning-stub
     COUCHDB: abacus-dbserver
+    SECURED: false
+    AUTHSERVER: undefined
+    CLIENTID: undefined
+    CLIENTSECRET: undefined
+    JWTKEY: undefined
+    JWTALGO: undefined

--- a/lib/aggregation/accumulator/src/index.js
+++ b/lib/aggregation/accumulator/src/index.js
@@ -33,18 +33,21 @@ const debug = require('abacus-debug')('abacus-usage-accumulator');
 // Secure the routes or not
 const secured = () => process.env.SECURED === 'true' ? true : false;
 
+// OAuth bearer access token with Abacus system access scopes
+let systemToken;
+
 // Resolve service URIs
 const uris = urienv({
   couchdb: 5984,
   aggregator: 9200
 });
 
-// Return OAuth admin scopes needed to write input docs
+// Return OAuth system scopes needed to write input docs
 const iwscope = (udoc) => secured() ? {
   system: ['abacus.usage.write']
 } : undefined;
 
-// Return OAuth admin scopes needed to read input and output docs
+// Return OAuth system scopes needed to read input and output docs
 const rscope = (udoc) => secured() ? {
   system: ['abacus.usage.read']
 } : undefined;
@@ -115,7 +118,7 @@ const accumulate = function *(a, u, auth) {
   const oldend = a ? dateUTCNumbify(a.end) : 0;
 
   // Retrieve the configured metrics for the resource
-  const conf = yield config(u.resource_id, u.end, auth);
+  const conf = yield config(u.resource_id, u.end, systemToken && systemToken());
 
   // Calculate new accumulated usage
   const newa = extend({}, amerge, {
@@ -223,7 +226,8 @@ const accumulator = () => {
     sink : {
       host: uris.aggregator,
       port: 9200,
-      post: '/v1/metering/accumulated/usage'
+      post: '/v1/metering/accumulated/usage',
+      authentication: systemToken
     }
   });
 
@@ -233,7 +237,17 @@ const accumulator = () => {
 };
 
 // Command line interface, create the accumulator app and listen
-const runCLI = () => accumulator().listen();
+const runCLI = () => {
+  // Cache and schedule the system token renewal
+  if (secured()) {
+    systemToken = oauth.cache(process.env.AUTHSERVER, process.env.CLIENTID,
+      process.env.CLIENTSECRET, 'abacus.usage.write abacus.usage.read');
+
+    systemToken.start();
+  }
+
+  accumulator().listen();
+};
 
 // Export our public functions
 module.exports = accumulator;

--- a/lib/aggregation/accumulator/src/test/test.js
+++ b/lib/aggregation/accumulator/src/test/test.js
@@ -36,10 +36,11 @@ const reqmock = extend({}, request, {
 require.cache[require.resolve('abacus-request')].exports = reqmock;
 
 // Mock the oauth module with a spy
-let validatorspy, authorizespy;
+let validatorspy, authorizespy, cachespy;
 const oauthmock = extend({}, oauth, {
   validator: () => (req, res, next) => validatorspy(req, res, next),
-  authorize: (auth, escope) => authorizespy(auth, escope)
+  authorize: (auth, escope) => authorizespy(auth, escope),
+  cache: () => cachespy()
 });
 require.cache[require.resolve('abacus-cfoauth')].exports = oauthmock;
 
@@ -48,6 +49,12 @@ const accumulator = require('..');
 describe('abacus-usage-accumulator', () => {
   it('accumulates usage over time', function(done) {
     this.timeout(60000);
+    cachespy = spy(() => {
+      const f = () => undefined;
+      f.start = () => undefined;
+      return f;
+    });
+
 
     // Create a test accumulator app
     const app = accumulator();
@@ -490,6 +497,11 @@ describe('abacus-usage-accumulator', () => {
     const verify = (secured, done) => {
       // Set the SECURED environment variable
       process.env.SECURED = secured ? 'true' : 'false';
+      cachespy = spy(() => {
+        const f = () => undefined;
+        f.start = () => undefined;
+        return f;
+      });
 
       // Create a test accumulator app
       const app = accumulator();


### PR DESCRIPTION
Abacus processing pipeline should use its own system token to move
the processing to next step in the pipeline.

See tracker [#101701306] and github issue #35.
