### PR TITLE
Use system token to get resource config at usage reporting service

### DIFF
--- a/lib/aggregation/reporting/manifest.yml
+++ b/lib/aggregation/reporting/manifest.yml
@@ -10,5 +10,8 @@ applications:
     ACCOUNT: abacus-account-stub
     COUCHDB: abacus-dbserver
     SECURED: false
+    AUTHSERVER: undefined
+    CLIENTID: undefined
+    CLIENTSECRET: undefined
     JWTKEY: undefined
     JWTALGO: undefined

--- a/lib/aggregation/reporting/src/index.js
+++ b/lib/aggregation/reporting/src/index.js
@@ -52,10 +52,14 @@ const edebug = require('abacus-debug')('e-abacus-usage-reporting');
 // Secure the routes or not
 const secured = () => process.env.SECURED === 'true' ? true : false;
 
+// OAuth bearer access token with Abacus system access scopes
+let systemToken;
+
 // Resolve service URIs
 const uris = urienv({
   couchdb: 5984,
-  account: 9381
+  account: 9381,
+  authserver: 9382
 });
 
 // Configure rated usage db
@@ -84,7 +88,8 @@ const chargeUsage = function *(t, r, auth) {
   const chargeResource = function *(rs) {
 
     // Find the metrics configured for the given resource
-    const conf = yield config(rs.resource_id, r.end, auth);
+    const conf = yield config(rs.resource_id, r.end,
+      systemToken && systemToken());
 
     // Compute the charge of each metric under the resource's plans
     const plans = map(rs.plans, (p) => {
@@ -201,7 +206,8 @@ const summarizeUsage = function *(t, a, auth) {
   const summarizeResource = function *(rs) {
 
     // Find the metrics configured for the given resource
-    const conf = yield config(rs.resource_id, a.end, auth);
+    const conf = yield config(rs.resource_id, a.end,
+      systemToken && systemToken());
 
     // Summarize a metric
     const summarizeMetric = (m) => {
@@ -423,12 +429,10 @@ const retrieveUsage = function *(req) {
   debug('Retrieving rated usage for organization %s on %s',
     req.params.organization_id, req.params.time);
 
-  const auth = req.headers && req.headers.authorization ?
-    req.headers.authorization : undefined;
-
   // Retrieve and return the rated usage for the given org and time
   const doc = yield orgUsage(req.params.organization_id,
-    req.params.time ? parseInt(req.params.time) : undefined, auth);
+    req.params.time ? parseInt(req.params.time) : undefined,
+    req.headers && req.headers.authorization);
 
   return {
     body: omit(dbclient.undbify(doc),
@@ -455,8 +459,8 @@ routes.get(
     debug(
       'Retrieving rated usage using graphql query %s', req.params.query);
 
-    const q = req.headers.authorization ? req.params.query.replace(
-      /(.*)\((.*)/,
+    const q = req.headers && req.headers.authorization ?
+      req.params.query.replace(/(.*)\((.*)/,
       '$1(authorization: "' + req.headers.authorization + '", $2') :
       req.params.query;
     debug('Modified graphql query %s', q)
@@ -488,7 +492,17 @@ const reporting = () => {
 };
 
 // Command line interface, create the aggregator app and listen
-const runCLI = () => reporting().listen();
+const runCLI = () => {
+  // Cache and schedule the system token renewal
+  if (secured()) {
+    systemToken = oauth.cache(uris.authserver, process.env.CLIENTID,
+      process.env.CLIENTSECRET, 'abacus.usage.write abacus.usage.read');
+
+    systemToken.start();
+  }
+
+  reporting().listen();
+};
 
 // Export our public functions
 module.exports = reporting;

--- a/lib/aggregation/reporting/src/test/test.js
+++ b/lib/aggregation/reporting/src/test/test.js
@@ -41,9 +41,15 @@ require.cache[require.resolve('abacus-cluster')].exports =
   extend((app) => app, cluster);
 
 // Mock the oauth module with a spy
-const oauthspy = spy((req, res, next) => next());
+const validatorspy = spy((req, res, next) => next());
+const cachespy = spy(() => {
+  const f = () => undefined;
+  f.start = () => undefined;
+  return f;
+});
 const oauthmock = extend({}, oauth, {
-  validator: () => oauthspy
+  validator: () => validatorspy,
+  cache: () => cachespy()
 });
 require.cache[require.resolve('abacus-cfoauth')].exports = oauthmock;
 
@@ -2904,7 +2910,7 @@ describe('abacus-usage-report', () => {
 
     const verify = (secured, done) => {
       process.env.SECURED = secured ? 'true' : 'false';
-      oauthspy.reset();
+      validatorspy.reset();
 
       // Create a test report app
       const app = report();
@@ -2916,7 +2922,7 @@ describe('abacus-usage-report', () => {
       const cb = () => {
         if(++cbs === 2) { 
           // Check oauth validator spy
-          expect(oauthspy.callCount).to.equal(secured ? 2 : 0);
+          expect(validatorspy.callCount).to.equal(secured ? 2 : 0);
 
           done();
         }
@@ -3025,7 +3031,7 @@ describe('abacus-usage-report', () => {
 
     const verify = (secured, done) => {
       process.env.SECURED = secured ? 'true' : 'false';
-      oauthspy.reset();
+      validatorspy.reset();
 
       // Create a test report app
       const app = report();
@@ -3046,7 +3052,7 @@ describe('abacus-usage-report', () => {
           expect(val.body).to.deep.equal(expected);
 
           // Check oauth validator spy
-          expect(oauthspy.callCount).to.equal(secured ? 1 : 0);
+          expect(validatorspy.callCount).to.equal(secured ? 1 : 0);
 
           done();
         });
@@ -3114,7 +3120,7 @@ describe('abacus-usage-report', () => {
 
     const verify = (secured, done) => {
       process.env.SECURED = secured ? 'true' : 'false';
-      oauthspy.reset();
+      validatorspy.reset();
 
       // Create a test report app
       const app = report();
@@ -3126,7 +3132,7 @@ describe('abacus-usage-report', () => {
       const cb = () => {
         if (++cbs === 4) {
           // Check oauth validator spy
-          expect(oauthspy.callCount).to.equal(secured ? 6 : 0);
+          expect(validatorspy.callCount).to.equal(secured ? 6 : 0);
 
           done();
         }


### PR DESCRIPTION
Abacus usage reporting service should use its own system token to get resource
configuration.

See tracker [#104195630].
