### PR TITLE
Fix resource config to handle error responses from provisioning

### DIFF
--- a/lib/config/resource/src/index.js
+++ b/lib/config/resource/src/index.js
@@ -15,12 +15,14 @@ const lru = require('lru-cache');
 const formula = require('./formula.js');
 
 const extend = _.extend;
+const pick = _.pick;
 const map = _.map;
 
 const brequest = retry(breaker(batch(request)));
 
 // Setup debug log
 const debug = require('abacus-debug')('abacus-resource-config');
+const edebug = require('abacus-debug')('e-abacus-resource-config');
 
 // Resolve service URIs
 const uris = urienv({
@@ -122,8 +124,22 @@ const config = (rid, time, auth, cb) => {
         time: t
       }), (err, val) => {
         if(err)
-          return cb(err);
-        
+          return unlock(cb(err));
+
+        // Authorization failed. Unable to retrieve resource configuration
+        // for the given time
+        if (val.statusCode !== 200) {
+          edebug('Unable to retrieve resource configuration, %d - %o',
+            val.statusCode, val.body || '');
+          debug('Unable to retrieve resource configuration, %d - %o',
+            val.statusCode, val.body || '');
+
+          // Unlock and throw response object as an exception
+          // to stop further processing
+          return unlock(cb(extend({}, pick(val, ['statusCode', 'body']),
+            { headers: pick(val.headers, 'www-authenticate') })));
+        }
+
         // Compile and return the config
         return unlock(
           cb(undefined, cache(k, compile(val.body))));


### PR DESCRIPTION
Handle non-200 HTTP response codes and return an error when retrieving
resource configuration details.

Fixes #99.
