### PR TITLE
Make HTTP protocol and port # as configurable at OAUTH module

### DIFF
--- a/lib/utils/cfoauth/src/index.js
+++ b/lib/utils/cfoauth/src/index.js
@@ -7,13 +7,11 @@
 //  CLIENT_ID - client credentials
 //  CLIENT_SECRET - client credentials
 
-const url = require('url');
 const _ = require('underscore');
 const jwt = require('jsonwebtoken');
 const request = require('abacus-request');
 const retry = require('abacus-retry');
 
-const extend = _.extend;
 const isEmpty = _.isEmpty;
 const intersection = _.intersection;
 const difference = _.difference;
@@ -23,68 +21,62 @@ const edebug = require('abacus-debug')('e-abacus-oauth');
 
 const get = retry(request.get);
 
-// Retrieve token endpoint from the CF API endpoint
+// Retrieve token endpoint from an authorization server
 const tokenEndpoint = (apiHostName, cb) => {
-  debug('Retrieving oauth server');
+  debug('Retrieving token endpoint information from authorization server, %o',
+    apiHostName);
 
-  get('http://' + (apiHostName ? apiHostName : process.env.API_HOST_NAME) +
-    '/v2/info',
-    (error, response) => {
-      if (error) {
-        debug('Error oauth server %o', error);
-        return cb(error);
+  get((apiHostName || process.env.API_HOST_NAME) + '/v2/info',
+    (err, val) => {
+      if (err) {
+        debug('Error getting oauth server information, %o', err);
+        return cb(err);
       }
 
-      if (response.statusCode >= 400) {
+      if (val.statusCode >= 400) {
         debug('%s - %s - has returned an error - response %d' +
-          (response.body ? ' %o' : '%s'), response.request.method,
-          response.request.path, response.statusCode,
-          response.body ? response.body : '');
-        return cb(new Error('Unable  to get oauth server information'));
+          (val.body ? ' %o' : '%s'), val.request.method,
+          val.request.path, val.statusCode,
+          val.body || '');
+        return cb(new Error('Unable to get oauth server information'));
       }
 
-      debug('Retrieved %o', response.body.token_endpoint);
+      debug('Retrieved %o', val.body.token_endpoint);
 
       // Return endpoint host
-      const u = url.parse(response.body.token_endpoint);
-      cb(null, u.hostname + (u.port ? ':' + u.port : ''));
+      cb(undefined, val.body.token_endpoint);
     }
   );
 };
 
 // Retrieve token from the endpoint using client credentials
 // OAuth trusted client flow.
-// The tokenInfo object is augmented with the token expiry time
 const newToken = (tokenEndpoint, clientId, secret, scopes, cb) => {
-  debug('Retrieving token info');
+  debug('Retrieving token from access token endpoint, %o', tokenEndpoint);
 
-  get('http://' +
-    (tokenEndpoint ? tokenEndpoint : process.env.TOKEN_ENDPOINT) +
+  get((tokenEndpoint || process.env.TOKEN_ENDPOINT) +
     '/oauth/token?grant_type=client_credentials' +
     (scopes ? '&scope=' + encodeURIComponent(scopes) : ''),
     {
       headers: {
         authorization: 'Basic ' + new Buffer(
-          (clientId ? clientId : process.env.CLIENT_ID) + ':' +
-          (secret ? secret : process.env.CLIENT_SECRET)
+          (clientId || process.env.CLIENT_ID) + ':' +
+          (secret || process.env.CLIENT_SECRET)
         ).toString('base64')
       }
-    }, (error, response) => {
-      if (error) {
-        debug('Error getting token : %o', error);
-        return cb(error);
+    }, (err, val) => {
+      if (err) {
+        debug('Error getting token : %o', err);
+        return cb(err);
       }
 
-      if (response.statusCode >= 400) {
-        debug('Error getting token, response %s, error %o', response.statusCode,
-          response.body ? response.body : '');
+      if (val.statusCode >= 400) {
+        debug('Error getting token, response %s, error %o', val.statusCode,
+          val.body || '');
         return cb(new Error('Unable to get OAUTH token'));
       }
 
-      const tokenInfo = response.body;
-      cb(null, extend({}, tokenInfo, {
-        expiry: Date.now() + tokenInfo.expires_in * 1000
-      }));
+      cb(undefined, val.body);
     });
 };
 

--- a/lib/utils/cfoauth/src/test/test.js
+++ b/lib/utils/cfoauth/src/test/test.js
@@ -15,8 +15,8 @@ const reqmock = extend({}, request, {
 });
 require.cache[require.resolve('abacus-request')].exports = reqmock;
 
-process.env.API_HOST_NAME = 'localhost:25000';
-process.env.TOKEN_ENDPOINT = 'localhost:35000';
+process.env.API_HOST_NAME = 'http://localhost:25000';
+process.env.TOKEN_ENDPOINT = 'http://localhost:35000';
 process.env.CLIENT_ID = 'clientid';
 process.env.CLIENT_SECRET = 'password';
 
@@ -185,40 +185,40 @@ describe('Token endpoint', () => {
 
   describe('Get token endpoint', () => {
     it('Endpoint from argument', (done) => {
-      oauth.tokenEndpoint('localhost:25000', (err, val) => {
-        expect(err).to.equal(null);
-        expect(val).to.equal('uaa.cf.org');
+      oauth.tokenEndpoint('http://localhost:25000', (err, val) => {
+        expect(err).to.equal(undefined);
+        expect(val).to.equal('https://uaa.cf.org');
         done();
       });
     });
 
     it('Endpoint from env property', (done) => {
       oauth.tokenEndpoint(null, (err, val) => {
-        expect(err).to.equal(null);
-        expect(val).to.equal('uaa.cf.org');
+        expect(err).to.equal(undefined);
+        expect(val).to.equal('https://uaa.cf.org');
         done();
       });
     });
 
     it('Endpoint from argument - connection error', (done) => {
-      oauth.tokenEndpoint('localhost:25001', (err, val) => {
-        expect(err).to.not.equal(null);
+      oauth.tokenEndpoint('http://localhost:25001', (err, val) => {
+        expect(err).to.not.equal(undefined);
         expect(val).to.equal(undefined);
         done();
       });
     });
 
     it('Endpoint from argument - 400 error', (done) => {
-      oauth.tokenEndpoint('localhost:25000/e1', (err, val) => {
-        expect(err).to.not.equal(null);
+      oauth.tokenEndpoint('http://localhost:25000/e1', (err, val) => {
+        expect(err).to.not.equal(undefined);
         expect(val).to.equal(undefined);
         done();
       });
     });
 
     it('Endpoint from argument - 400 error, no body', (done) => {
-      oauth.tokenEndpoint('localhost:25000/e2', (err, val) => {
-        expect(err).to.not.equal(null);
+      oauth.tokenEndpoint('http://localhost:25000/e2', (err, val) => {
+        expect(err).to.not.equal(undefined);
         expect(val).to.equal(undefined);
         done();
       });
@@ -263,38 +263,36 @@ describe('Token', () => {
 
   describe('Get token', () => {
     it('Token from argument', (done) => {
-      oauth.newToken('localhost:35000', 'clientid', 'password', null,
+      oauth.newToken('http://localhost:35000', 'clientid', 'password', null,
         (err, val) => {
-          expect(err).to.equal(null);
-          // add the additional field (with actual time)
-          token.expiry = val.expiry;
+          expect(err).to.equal(undefined);
           expect(val).to.deep.equal(token);
           done();
         });
     });
 
     it('Token from argument - error', (done) => {
-      oauth.newToken('localhost:35001', 'clientid', 'password', null,
+      oauth.newToken('http://localhost:35001', 'clientid', 'password', null,
         (err, val) => {
-          expect(err).to.not.equal(null);
+          expect(err).to.not.equal(undefined);
           expect(val).to.equal(undefined);
           done();
         });
     });
 
     it('Token from argument - 400', (done) => {
-      oauth.newToken('localhost:35000/e1', 'clientid', 'password', null,
+      oauth.newToken('http://localhost:35000/e1', 'clientid', 'password', null,
         (err, val) => {
-          expect(err).to.not.equal(null);
+          expect(err).to.not.equal(undefined);
           expect(val).to.equal(undefined);
           done();
         });
     });
 
     it('Token from argument - 400 - no body', (done) => {
-      oauth.newToken('localhost:35000/e1', 'clientid', 'password', null,
+      oauth.newToken('http://localhost:35000/e1', 'clientid', 'password', null,
         (err, val) => {
-          expect(err).to.not.equal(null);
+          expect(err).to.not.equal(undefined);
           expect(val).to.equal(undefined);
           done();
         });
@@ -303,9 +301,7 @@ describe('Token', () => {
     it('Token from env property', (done) => {
       oauth.newToken(null, null, null, null,
         (err, val) => {
-          expect(err).to.equal(null);
-          // add the additional field (with actual time)
-          token.expiry = val.expiry;
+          expect(err).to.equal(undefined);
           expect(val).to.deep.equal(token);
           done();
         });
@@ -314,9 +310,7 @@ describe('Token', () => {
     it('Token from env property with scopes', (done) => {
       oauth.newToken(null, null, null, 'scim.read cloud_controller.read',
         (err, val) => {
-          expect(err).to.equal(null);
-          // add the additional field (with actual time)
-          token.expiry = val.expiry;
+          expect(err).to.equal(undefined);
           expect(val).to.deep.equal(token);
           done();
         });
@@ -662,7 +656,9 @@ describe('abacus-oauth', () => {
 
     // Add auth server REST endpoints
     app.get('/v2/info', (req, res) => {
-      res.send({ token_endpoint: 'http://' + req.headers.host });
+      res.send({
+        token_endpoint: [req.protocol, '://', req.headers.host].join('')
+      });
     });
 
     app.get('/oauth/token', (req, res) => {
@@ -683,7 +679,7 @@ describe('abacus-oauth', () => {
       // Setup a fake time
       const clock = sinon.useFakeTimers(Date.now());
 
-      const token = oauth.cache('localhost:' + server.address().port,
+      const token = oauth.cache('http://localhost:' + server.address().port,
         'valid', 'secret', 'scopes');
 
       token.start((err) => {
@@ -699,8 +695,8 @@ describe('abacus-oauth', () => {
     };
 
     // Unable to get a token from auth server's token endpoint
-    const invalidtoken = oauth.cache('localhost:' + server.address().port,
-      'valid', 'secret', 'invalid');
+    const invalidtoken = oauth.cache('http://localhost:' +
+      server.address().port, 'valid', 'secret', 'invalid');
 
     invalidtoken.start((err) => {
       expect(err).to.deep.equal(new Error('Unable to get OAUTH token'));


### PR DESCRIPTION
API_HOST_NAME and TOKEN_ENDPOINT need to be configured using
'protocol://hostname:port' format. For example expect
'https://localhost:25000' instead of localhost or localhost:25000.

Remove unused custom token expiration property from access token information.

Includes minor code updates to follow the naming conventions.

Implements #103.
