### PR TITLE
Implement OAuth authorization server stub

### DIFF
--- a/lib/stubs/authserver/.gitignore
+++ b/lib/stubs/authserver/.gitignore
@@ -1,0 +1,2 @@
+lib/**
+node_modules/**

--- a/lib/stubs/authserver/.npmrc
+++ b/lib/stubs/authserver/.npmrc
@@ -1,0 +1,1 @@
+optional=false

--- a/lib/stubs/authserver/README.md
+++ b/lib/stubs/authserver/README.md
@@ -1,0 +1,4 @@
+abacus-authserver-stub
+===
+
+Stub for an authorization server.

--- a/lib/stubs/authserver/manifest.yml
+++ b/lib/stubs/authserver/manifest.yml
@@ -1,0 +1,11 @@
+applications:
+- name: abacus-authserver-stub
+  host: abacus-authserver-stub
+  path: .cfpack/app.zip
+  instances: 1
+  memory: 512M
+  disk_quota: 512M
+  env:
+    SECURED: false
+    JWTKEY: undefined
+    JWTALGO: undefined

--- a/lib/stubs/authserver/package.json
+++ b/lib/stubs/authserver/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "abacus-authserver-stub",
+  "description": "Stub for an authrorization server",
+  "license": "Apache-2.0",
+  "version": "0.0.2-rc.1",
+  "private": true,
+  "homepage": "https://github.com/cloudfoundry-incubator/cf-abacus/lib/stubs/authserver",
+  "bugs": {
+    "url": "https://github.com/cloudfoundry-incubator/cf-abacus/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/cloudfoundry-incubator/cf-abacus.git"
+  },
+  "keywords": [
+    "cf",
+    "abacus"
+  ],
+  "files": [
+    ".npmrc",
+    "manifest.yml",
+    "lib/",
+    "src/"
+  ],
+  "main": "lib/index.js",
+  "scripts": {
+    "start": "webapp start --port 9382",
+    "stop": "webapp stop",
+    "babel": "babel",
+    "test": "eslint && mocha",
+    "lint": "eslint",
+    "pub": "publish",
+    "cfpush": "cfpack && cf push"
+  },
+  "dependencies": {
+    "babel-runtime": "^5.8.19",
+    "abacus-debug": "file:../../utils/debug",
+    "abacus-router": "file:../../utils/router",
+    "abacus-webapp": "file:../../utils/webapp",
+    "underscore": "^1.8.3",
+    "jsonwebtoken": "^5.0.5"
+  },
+  "devDependencies": {
+    "abacus-babel": "file:../../../tools/babel",
+    "abacus-cluster": "file:../../utils/cluster",
+    "abacus-cfpack": "file:../../../tools/cfpack",
+    "abacus-eslint": "file:../../../tools/eslint",
+    "abacus-mocha": "file:../../../tools/mocha",
+    "abacus-publish": "file:../../../tools/publish"
+  },
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">=2.0.0"
+  }
+}

--- a/lib/stubs/authserver/src/index.js
+++ b/lib/stubs/authserver/src/index.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const _ = require('underscore');
+const router = require('abacus-router');
+const webapp = require('abacus-webapp');
+const jwt = require('jsonwebtoken');
+
+const extend = _.extend;
+
+// Setup the debug log
+const debug = require('abacus-debug')('abacus-perf-test');
+
+// Create an express router
+const routes = router();
+
+// Retrieve token point information
+routes.get('/v2/info', function *(req) {
+  // return token endpoint URL to get a OAuth bearer access token
+  return {
+    body: {
+      token_endpoint: [req.protocol, '://', req.headers.host].join('')
+    }
+  };
+});
+
+// Retrieve OAuth bearer access token
+routes.get('/oauth/token', function *(req) {
+  debug('Get OAuth bearer access token');
+
+  // Default OAuth bearer access token
+  const token = {
+    jti: 'fa1b29fe-76a9-4c2d-903e-dddd0563a9e3',
+    sub: 'test-token',
+    client_id: 'test-token',
+    cid: 'test-token',
+    azp: 'test-token',
+    grant_type: 'client_credentials',
+    iss: req.url,
+    zid: 'authserver-stub',
+    aud: [
+      'abacus',
+      'account',
+      'provisioning'
+    ]
+  };
+
+  // Sign OAuth bearer access token with expected scopes
+  const signed = jwt.sign(extend(token, {
+    authorities: req.query.scope.split(' '),
+    scope: req.query.scope.split(' ')
+  }), process.env.JWTKEY || 'encode', {
+    algorithm: process.env.JWTALGO,
+    expiresIn: 43200
+  });
+
+  return {
+    body: {
+      access_token: signed,
+      token_type: 'bearer',
+      scope: req.query.scope,
+      expires_in: 43200
+    }
+  };
+});
+
+// Create an authorization server stub application
+const authserver = () => {
+  const app = webapp();
+  app.use(routes);
+  return app;
+};
+
+// Command line interface, create the app and listen
+const runCLI = () => authserver().listen();
+
+// Export our public functions
+module.exports = authserver;
+module.exports.runCLI = runCLI;

--- a/lib/stubs/authserver/src/test/test.js
+++ b/lib/stubs/authserver/src/test/test.js
@@ -1,0 +1,68 @@
+'use strict';
+
+// Stub for an authorization server
+
+const _ = require('underscore');
+const request = require('abacus-request');
+const cluster = require('abacus-cluster');
+const jwt = require('jsonwebtoken');
+
+const extend = _.extend;
+const omit = _.omit;
+
+// Mock the cluster module
+require.cache[require.resolve('abacus-cluster')].exports =
+  extend((app) => app, cluster);
+
+const authserver = require('..');
+
+describe('abacus-account-stub', () => {
+  it('get OAuth bearer access token', (done) => {
+    // Create an authorization server stub application
+    const app = authserver();
+
+    // Listen on an ephemeral port
+    const server = app.listen(0);
+
+    // Get authorization server access token endpoint
+    request.get('http://localhost::p/v2/info', {
+      p: server.address().port
+    }, (err, val) => {
+      expect(err).to.equal(undefined);
+      expect(val.statusCode).to.equal(200);
+
+      // Expect the access token endpoint to match the expectation
+      expect(val.body).to.deep.equal({
+        token_endpoint: ['http://localhost:', server.address().port].join('')
+      });
+
+      // Get OAuth bearer access token with scopes using client credentials
+      request.get(val.body.token_endpoint +
+        '/oauth/token?grant_type=client_credentials&scope=' +
+        encodeURIComponent('test.scope.write test.scope.read'), (err, val) => {
+          expect(err).to.equal(undefined);
+          expect(val.statusCode).to.equal(200);
+
+          // Expect token information to match the expectation
+          expect(omit(val.body, 'access_token')).to.deep.equal({
+            token_type: 'bearer',
+            scope: 'test.scope.write test.scope.read',
+            expires_in: 43200
+          });
+
+          // Use JWT to verify the OAuth bearer access token
+          jwt.verify(val.body.access_token, process.env.JWTKEY || 'encode', {
+            algorithms: process.env.JWTALGO
+          });
+
+          // Use JWT to decode the access token and verify the scopes
+          expect(jwt.decode(val.body.access_token, {
+            complete: true
+          }).payload.scope).to.deep.equal(['test.scope.write',
+            'test.scope.read']);
+
+          done();
+        });
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "abacus-usage-rate": "file:lib/aggregation/rate",
     "abacus-account-stub": "file:lib/stubs/account",
     "abacus-provisioning-stub": "file:lib/stubs/provisioning",
+    "abacus-authserver-stub": "file:lib/stubs/authserver",
     "abacus-cf-bridge": "file:lib/cf/bridge",
     "abacus-batch": "file:lib/utils/batch",
     "abacus-breaker": "file:lib/utils/breaker",


### PR DESCRIPTION
OAuth authorization server stub implements REST endpoints to retrieve access
token endpoint information and to get OAuth bearer access token with expected
scopes using the access token endpoint.

See #98.
