### PR TITLE
Re-enable CI to run performance test using a secured Abacus

### DIFF
--- a/bin/citest
+++ b/bin/citest
@@ -7,6 +7,6 @@
 # intergration test matrix, we would need 2197(= 13 * 13 * 13)
 # usage submissions to get above 90 percent regression coverage
 npm run itest -- -o 4 -i 4 -u 4  &&
-npm start && sleep 10s && npm run demo && npm run perf -- -o 1 -i 1 -u 1 && npm stop
-# export SECURED=true JWTKEY=encode JWTALGO=HS256 &&
-# npm start && sleep 10s && npm run perf -- -o 4 -i 4 -u 4 && npm stop
+npm start && sleep 10s && npm run demo && npm run perf -- -o 1 -i 1 -u 1 && npm stop &&
+export SECURED=true JWTKEY=encode JWTALGO=HS256 &&
+npm start && sleep 10s && npm run perf -- -o 4 -i 4 -u 4 && npm stop

--- a/etc/apps
+++ b/etc/apps
@@ -3,6 +3,7 @@
 # Print the names, paths and instance count of the Abacus apps
 cat <<EOF
 abacus-dbserver lib/utils/dbserver 1
+abacus-authserver-stub lib/stubs/authserver 1
 abacus-provisioning-stub lib/stubs/provisioning 1
 abacus-account-stub lib/stubs/account 1
 abacus-usage-collector lib/metering/collector 1

--- a/test/perf/src/test/test.js
+++ b/test/perf/src/test/test.js
@@ -244,12 +244,10 @@ describe('abacus-perf-test', () => {
       jti: 'fa1b29fe-76a9-4c2d-903e-dddd0563a9e3',
       sub: 'object-storage',
       authorities: [
-        'abacus.usage.object-storage.write',
-        'abacus.usage.write'
+        'abacus.usage.object-storage.write'
       ],
       scope: [
-        'abacus.usage.object-storage.write',
-        'abacus.usage.write'
+        'abacus.usage.object-storage.write'
       ],
       client_id: 'object-storage',
       cid: 'object-storage',
@@ -267,6 +265,7 @@ describe('abacus-perf-test', () => {
     // default algorithm (HS256)
     const auth = process.env.SECURED === 'true' ?
       jwt.sign(token, process.env.JWTKEY, {
+        algorithm: process.env.JWTALGO,
         expiresIn: 43200
       }) : undefined;
 


### PR DESCRIPTION
Include secured Abacus based performance test as part of CI build.

Add authorization server stub to the list of applications used with npm start
and npm stop scripts.

Remove 'abacus.usage.write' from the token scope when submitting usage to
secured Abacus.

Fixes #98.
