### PR TITLE
Add consumer id to the input and output doc keys

### DIFF
--- a/lib/aggregation/accumulator/src/index.js
+++ b/lib/aggregation/accumulator/src/index.js
@@ -54,16 +54,19 @@ const rscope = (udoc) => secured() ? {
 
 // Return the keys and times of our docs
 const ikey = (udoc) =>
-  [udoc.organization_id, udoc.resource_instance_id, udoc.plan_id].join('/');
+  [udoc.organization_id, udoc.resource_instance_id,
+    udoc.consumer_id || 'UNKNOWN', udoc.plan_id].join('/');
 
 const igroup = (udoc) =>
-  [udoc.organization_id, udoc.resource_instance_id, udoc.plan_id].join('/');
+  [udoc.organization_id, udoc.resource_instance_id,
+    udoc.consumer_id || 'UNKNOWN', udoc.plan_id].join('/');
 
 const itime = (udoc) =>
   seqid();
 
 const okeys = (udoc) =>
-  [[udoc.organization_id, udoc.resource_instance_id, udoc.plan_id].join('/')];
+  [[udoc.organization_id, udoc.resource_instance_id,
+    udoc.consumer_id || 'UNKNOWN', udoc.plan_id].join('/')];
 
 const otimes = (udoc) =>
   [map([udoc.start, udoc.end], seqid.pad16).join('/')];
@@ -243,7 +246,8 @@ const accumulator = () => {
       type: 'metered-usage',
       post: '/v1/metering/metered/usage',
       get: '/v1/metering/metered/usage' +
-        '/t/:tseq/k/:korganization_id/:kresource_instance_id/:kplan_id',
+        '/t/:tseq/k/:korganization_id/:kresource_instance_id' +
+        '/:kconsumer_id/:kplan_id',
       dbname: 'abacus-accumulator-metered-usage',
       wscope: iwscope,
       rscope: rscope,
@@ -254,7 +258,8 @@ const accumulator = () => {
     output: {
       type: 'accumulated_usage',
       get: '/v1/metering/accumulated/usage' +
-        '/k/:korganization_id/:kresource_instance_id/:kplan_id' +
+        '/k/:korganization_id/:kresource_instance_id' +
+        '/:kconsumer_id/:kplan_id' +
         '/t/:tend/:tstart',
       dbname: 'abacus-accumulator-accumulated-usage',
       rscope: rscope,

--- a/lib/aggregation/accumulator/src/test/test.js
+++ b/lib/aggregation/accumulator/src/test/test.js
@@ -49,39 +49,24 @@ require.cache[require.resolve('abacus-cfoauth')].exports = oauthmock;
 
 const accumulator = require('..');
 
-// Utility functions that compute a time from now
-const now = new Date();
-
 // Returns 2015-01-03 with the given hour for testing
 const time = (h) => Date.UTC(2015, 0, 3, h);
 
 describe('abacus-usage-accumulator', () => {
   let clock;
+
   beforeEach(() => {
     clock = sinon.useFakeTimers(Date.UTC(2015, 0, 3, 5), 'Date');
   });
+
   afterEach(() => {
     clock.restore();
   });
+
   it('accumulates usage over time', (done) => {
-    cachespy = spy(() => {
-      const f = () => undefined;
-      f.start = () => undefined;
-      return f;
-    });
-
-
-    // Create a test accumulator app
-    const app = accumulator();
-
-    // Listen on an ephemeral port
-    const server = app.listen(0);
-
-    // Define a sequence of usage for a resource instance, usage 222 and
-    // 223 represent usage for two consecutive time periods, then usage
-    // 224 comes as a duplicate of usage 222 and should be skipped
+    // Metered usage template
     const usageTemplate = (u, h, p, st, lapi, hapi, mem) => ({
-      normalized_usage_id: (332 + u).toString(),
+      normalized_usage_id: (330 + u).toString(),
       start: time(h),
       end: time(h + 1),
       collected_usage_id: '555',
@@ -100,178 +85,76 @@ describe('abacus-usage-accumulator', () => {
         { metric: 'memory', quantity: { consuming: mem, since: time(h) } }
       ]
     });
+
+    // Define a sequence of usage for a resource instance:
+    // usage 330 and 331 represent usage for two consecutive time periods,
+    // then usage 332 comes as a duplicate of usage 330 and should be skipped,
+    // usage 333 and 334 represent usage for two consecutive days for a
+    // different plan than the first set,
+    // usage 335 repsent usage for a different consumer, but otherwise same as
+    // usage 333 and should not be skipped as duplicate and should be
+    // accumulated separately
     const usage = [
-      usageTemplate(0, 0, 'basic', 1, 0.01, 20, 6),
-      usageTemplate(1, 1, 'basic', 1, 0.01, 20, 4),
+      usageTemplate(0, 0, 'basic', 1, 0.03, 20, 6),
+      usageTemplate(1, 1, 'basic', 1, 0.03, 20, 6),
       usageTemplate(2, 0, 'basic', 1, 0.01, 20, 6),
       usageTemplate(3, 2, 'standard', 1, 0.01, 20, 4),
-      usageTemplate(4, -22, 'standard', 1, 0.01, 20, 4)
+      usageTemplate(4, -22, 'standard', 1, 0.01, 20, 4),
+      extend(usageTemplate(5, 2, 'standard', 1, 1, 200, 40), {
+        consumer_id: 'external:cceae239-f3f8-483c-9dd0-de6781c38bcc'
+      })
     ];
 
-    // Handle callback checks
-    let checks = 0;
-    const check = () => {
-      if(++checks == 3) done();
-    };
+    // Possible expected accumulated values
+    const expected = [{
+      metric: 'thousand_light_api_calls',
+      quantity: [[0], [0], [0],
+       [{ previous: 0.03, current: 0.06 }, 0, 0],
+       [{ previous: 0.03, current: 0.06 }, 0]
+      ]
+    }, {
+      metric: 'memory',
+      quantity: [[0],[0],[0],
+        [{ previous: { consumed: 0, consuming: 6, since: 1420243200000 },
+           current: { consumed: 21600000, consuming: 6, since: 1420246800000 }
+        }, 0, 0],
+        [{ previous: { consumed: 0, consuming: 6, since: 1420243200000 },
+           current: { consumed: 21600000, consuming: 6, since: 1420246800000 }
+        }, 0]
+      ]
+    }, {
+      metric: 'thousand_light_api_calls',
+      quantity: [[0], [0], [0],
+        [{ current: 0.01 }, { current: 0.01 }, 0],
+        [{ previous: 0.01, current: 0.02 }, 0]
+      ]
+    }, {
+      metric: 'memory',
+      quantity: [[0],[0],[0],
+        [{ current: { consumed: 0, consuming: 4, since: 1420250400000 } },
+         { current: { consumed: 0, consuming: 4, since: 1420164000000 } },
+        0],
+        [{ previous: { consumed: 0, consuming: 4, since: 1420250400000 },
+           current: { consumed: -345600000, consuming: 4, since: 1420164000000 }
+        }, 0]
+      ]
+    }, {
+      metric: 'thousand_light_api_calls',
+      quantity: [[0],[0],[0],
+        [{ current: 1 }, 0, 0],
+        [{ current: 1 }, 0]
+      ]
+    }, {
+      metric: 'memory',
+      quantity: [[0],[0],[0],
+        [{ current: { consumed: 0, consuming: 40, since: 1420250400000 } },
+        0, 0],
+        [{ current: { consumed: 0, consuming: 40, since: 1420250400000 } },
+        0]
+      ]
+    }];
 
-    postspy = (reqs, cb) => {
-      debug('Posted new accumulated usage %o', reqs);
-
-      // Expect accumulated usage to be posted to the aggregator service
-      expect(reqs[0][0])
-        .to.equal('http://localhost:9300/v1/metering/accumulated/usage');
-
-      // Expect accumulated values
-      const val = reqs[0][1];
-      if(val.body.plan_id === 'basic')
-        try {
-          const expected1 = [[0], [0], [0],
-            [{ previous: 0.01, current: 0.02 }, 0, 0],
-            [{ previous: 0.01, current: 0.02 }, 0]
-          ];
-          const expected3 = [[0], [0], [0],
-            [{ current:
-              { consuming: 4, consumed: 21600000, since: 1420246800000 },
-              previous: { consuming: 6, consumed: 0, since: 1420243200000 }
-            }, 0, 0],
-            [{ current:
-              { consuming: 4, consumed: 21600000, since: 1420246800000 },
-              previous: { consuming: 6, consumed: 0, since: 1420243200000 }
-            }, 0]
-          ];
-
-          debug('Accumulated basic usage[1] %o',
-              val.body.accumulated_usage[1].quantity);
-          debug('Expected basic usage[1] %o', expected1);
-          expect(val.body.accumulated_usage[1].quantity)
-            .to.deep.equal(expected1);
-
-          debug('Accumulated basic usage[3] %o',
-              val.body.accumulated_usage[3].quantity);
-          debug('Expected basic usage[3] %o', expected3);
-          expect(val.body.accumulated_usage[3].quantity)
-            .to.deep.equal(expected3);
-          check();
-        }
-        catch(e) {
-          debug('Unmatched usage %o', e);
-        }
-
-      if(val.body.plan_id === 'standard')
-        try {
-          const expected1 = [[0], [0], [0],
-            [{ current: 0.01 }, { current: 0.01 }, 0],
-            [{ previous: 0.01, current: 0.02 }, 0]
-          ];
-          const expected3 = [[0], [0], [0],
-            [
-              { current: { consuming: 4, consumed: 0, since: 1420250400000 } },
-              { current: { consuming: 4, consumed: 0, since: 1420164000000 } },
-              0
-            ],
-            [
-              { current:
-                { consuming: 4, consumed: -345600000, since: 1420164000000 },
-                previous:
-                { consuming: 4, consumed: 0, since: 1420250400000 }
-              },
-              0
-            ]
-          ];
-
-          debug('Accumulated basic usage[1] %o',
-              val.body.accumulated_usage[1].quantity);
-          debug('Expected basic usage[1] %o', expected1);
-          expect(val.body.accumulated_usage[1].quantity)
-            .to.deep.equal(expected1);
-
-          debug('Accumulated basic usage[3] %o',
-              val.body.accumulated_usage[3].quantity);
-          debug('Expected basic usage[3] %o', expected3);
-          expect(val.body.accumulated_usage[3].quantity)
-            .to.deep.equal(expected3);
-          check();
-        }
-        catch(e) {
-          debug('Unmatched usage %o', e);
-        }
-
-      cb(undefined, [[undefined, {
-        statusCode: 200
-      }]]);
-    };
-
-    // Initialize oauth spies
-    validatorspy = spy((req, res, next) => next());
-    authorizespy = spy(function() {});
-
-    // Post usage to the accumulator
-    const post = () => {
-      transform.reduce(usage, (a, u, i, l, cb) =>
-        request.post('http://localhost::p/v1/metering/metered/usage', {
-          p: server.address().port,
-          body: u
-        }, (err, val) => {
-          expect(err).to.equal(undefined);
-
-          // Expect a 201 with the location of the accumulated usage
-          if(i !== 2) {
-            expect(val.statusCode).to.equal(201);
-            expect(val.headers.location).to.not.equal(undefined);
-
-            // Get metered usage back, expecting what we posted
-            request.get(val.headers.location, {}, (err, val) => {
-              expect(err).to.equal(undefined);
-              expect(val.statusCode).to.equal(200);
-
-              expect(omit(
-                val.body, 'id', 'processed')).to.deep.equal(usage[i]);
-              cb();
-            });
-
-          }
-          else {
-            // Expect a 409 reporting duplicate usage
-            expect(val.statusCode).to.equal(409);
-            cb();
-          }
-
-        }), undefined, check);
-    };
-
-    // Run the above steps
-    post();
-  });
-
-  it('accumulates usage using unsecured and secured server', (done) => {
-
-    const metered = {
-      normalized_usage_id: '332',
-      collected_usage_id: '555',
-      metered_usage_id: '422',
-      resource_id: 'test-resource',
-      resource_instance_id: '0b39fa70-a65f-4183-bae8-385633ca5c87',
-      start: Date.UTC(now.getUTCFullYear(),
-        now.getUTCMonth(), now.getUTCDate(), 0),
-      end: Date.UTC(now.getUTCFullYear(),
-        now.getUTCMonth(), now.getUTCDate(), 1),
-      plan_id: 'basic',
-      region: 'us',
-      organization_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
-      space_id: 'aaeae239-f3f8-483c-9dd0-de5d41c38b6a',
-      consumer_id: 'external:bbeae239-f3f8-483c-9dd0-de6781c38bab',
-      metered_usage: [{
-        metric: 'storage',
-        quantity: 1
-      }, {
-        metric: 'thousand_light_api_calls',
-        quantity: 0.01
-      }, {
-        metric: 'heavy_api_calls',
-        quantity: 20
-      }]
-    };
-
+    // Verify secured or unsecured accumulator
     const verify = (secured, done) => {
       // Set the SECURED environment variable
       process.env.SECURED = secured ? 'true' : 'false';
@@ -291,36 +174,106 @@ describe('abacus-usage-accumulator', () => {
       validatorspy = spy((req, res, next) => next());
       authorizespy = spy(function() {});
 
-      // Post usage for a resource, expecting a 201 response
-      request.post('http://localhost::p/v1/metering/metered/usage', {
-        p: server.address().port,
-        body: extend({}, metered, { end: 1420245000000 + (secured ? 2 : 1) })
-      }, (err, val) => {
-        expect(err).to.equal(undefined);
-        expect(val.statusCode).to.equal(201);
+      // Handle callback checks and at the end, verify the expectation
+      // of sink payload
+      let checks = 0, matched = 0, unmatched = 0;
+      const check = () => {
+        if(++checks == 6) {
+          expect(matched).to.equal(3);
+          expect(unmatched).to.equal(2);
+          done();
+        }
+      };
 
-        // Check oauth validator and authorize spy
-        expect(validatorspy.callCount).to.equal(secured ? 1 : 0);
-        expect(authorizespy.args[0][0]).to.equal(undefined);
-        expect(authorizespy.args[0][1]).to.deep.equal(secured ? {
-          system: ['abacus.usage.write']
-        } : undefined);
+      // Sink post spy handler
+      postspy = (reqs, cb) => {
+        debug('Posted new accumulated usage %o', reqs);
 
-        // Get usage, expecting what we posted
-        brequest.get(val.headers.location, {}, (err, val) => {
+        // Expect accumulated usage to be posted to the aggregator service
+        expect(reqs[0][0])
+          .to.equal('http://localhost:9300/v1/metering/accumulated/usage');
+
+        // Expect accumulated values
+        const val = reqs[0][1];
+        try {
+          debug('Verify accumulated usage[1] %o',
+            val.body.accumulated_usage[1]);
+          expect(expected).to.deep.include(val.body.accumulated_usage[1]);
+
+          debug('Verify accumulated usage[3] %o',
+            val.body.accumulated_usage[3]);
+          expect(expected).to.deep.include(val.body.accumulated_usage[3]);
+
+          debug('Verified accumulated usage');
+          matched++;
+        }
+        catch(e) {
+          unmatched++;
+          debug('Unable to verify accumulated usage %o', e);
+        }
+
+        check();
+        cb(undefined, [[undefined, { statusCode: 200 }]]);
+      };
+
+      // Post usage one by one
+      transform.reduce(usage, (a, u, i, l, cb) => {
+        const uval = extend({}, u, {
+          resource_instance_id: ['0b39fa70-a65f-4183-bae8-385633ca5c87',
+            secured ? 1 : 0].join('-')
+        });
+
+        request.post('http://localhost::p/v1/metering/metered/usage', {
+          p: server.address().port,
+          body: uval
+        }, (err, val) => {
           expect(err).to.equal(undefined);
-          expect(val.statusCode).to.equal(200);
 
           // Check oauth validator and authorize spy
-          expect(validatorspy.callCount).to.equal(secured ? 3 : 0);
-          expect(authorizespy.args[1][0]).to.equal(undefined);
-          expect(authorizespy.args[1][1]).to.deep.equal(secured ? {
-            system: ['abacus.usage.read']
+          expect(validatorspy.callCount).to.equal(secured ? 1 : 0);
+          expect(authorizespy.args[0][0]).to.equal(undefined);
+          expect(authorizespy.args[0][1]).to.deep.equal(secured ? {
+            system: ['abacus.usage.write']
           } : undefined);
 
-          done();
-        });
-      });
+          // Reset the OAuth spies before moving onto the next
+          const done = () => {
+            validatorspy.reset();
+            authorizespy.reset();
+            cb();
+          };
+
+          // Expect a 201 with the location of the accumulated usage
+          if(i !== 2) {
+            expect(val.statusCode).to.equal(201);
+            expect(val.headers.location).to.not.equal(undefined);
+
+            // Get metered usage back, expecting what we posted
+            brequest.get(val.headers.location, {}, (err, val) => {
+              expect(err).to.equal(undefined);
+              expect(val.statusCode).to.equal(200);
+
+              // Check oauth validator and authorize spy
+              expect(validatorspy.callCount).to.equal(secured ? 3 : 0);
+              expect(authorizespy.args[1][0]).to.equal(undefined);
+              expect(authorizespy.args[1][1]).to.deep.equal(secured ? {
+                system: ['abacus.usage.read']
+              } : undefined);
+
+              expect(omit(
+                val.body, 'id', 'processed')).to.deep.equal(uval);
+              done();
+            });
+
+          }
+          else {
+            // Expect a 409 reporting duplicate usage
+            expect(val.statusCode).to.equal(409);
+            done();
+          }
+
+        })
+      }, undefined, check);
     };
 
     // Verify using an unsecured server and then verify using a secured server

--- a/lib/metering/meter/src/index.js
+++ b/lib/metering/meter/src/index.js
@@ -47,13 +47,15 @@ const rscope = (udoc) => secured() ? {
 
 // Return the keys and times of our docs
 const ikey = (udoc) =>
-  [udoc.organization_id, udoc.resource_instance_id, udoc.plan_id].join('/');
+  [udoc.organization_id, udoc.resource_instance_id,
+    udoc.consumer_id || 'UNKNOWN', udoc.plan_id].join('/');
 
 const itime = (udoc) =>
   seqid();
 
 const okeys = (udoc) =>
-  [[udoc.organization_id, udoc.resource_instance_id, udoc.plan_id].join('/')];
+  [[udoc.organization_id, udoc.resource_instance_id,
+    udoc.consumer_id || 'UNKNOWN', udoc.plan_id].join('/')];
 
 const otimes = (udoc) =>
   [map([udoc.start, udoc.end], seqid.pad16).join('/')];
@@ -111,7 +113,8 @@ const metering = () => {
       type: 'normalized_usage',
       post: '/v1/metering/normalized/usage',
       get: '/v1/metering/normalized/usage' + 
-        '/t/:tseq/k/:korganization_id/:kresource_instance_id/:kplan_id',
+        '/t/:tseq/k/:korganization_id/:kresource_instance_id' +
+        '/:kconsumer_id/:kplan_id',
       dbname: 'abacus-meter-normalized-usage',
       wscope: iwscope,
       rscope: rscope,
@@ -121,7 +124,8 @@ const metering = () => {
     output: {
       type: 'metered_usage',
       get: '/v1/metering/metered/usage' +
-        '/k/:korganization_id/:kresource_instance_id/:kplan_id' +
+        '/k/:korganization_id/:kresource_instance_id' +
+        '/:kconsumer_id/:kplan_id' +
         '/t/:tend/:tstart',
       dbname: 'abacus-meter-metered-usage',
       rscope: rscope,


### PR DESCRIPTION
Add consumer id to the input and output doc keys of the meter and
accumulator services.

Update unit test to verify accumulated values for two different consumers.

Refactor, cleanup and merge unit tests into one.

Fixes #130
