### PR TITLE
Improve performance of usage rating service

### DIFF
--- a/lib/aggregation/rate/src/index.js
+++ b/lib/aggregation/rate/src/index.js
@@ -31,6 +31,7 @@ const brequest = yieldable(retry(breaker(batch(request))));
 const lock = yieldable(lockcb);
 
 const tmap = yieldable(transform.map);
+const treduce = yieldable(transform.reduce);
 
 const config = yieldable(configcb);
 const prices = yieldable(pricescb);
@@ -85,35 +86,46 @@ const countries = lru({
 });
 
 // Return the pricing country configured for an organization's account
-const pricingCountry = function *(oid, auth) {
-  const unlock = yield lock(oid);
-  try {
-    debug('Retrieving pricing country for org %s', oid);
+// using batch and group by organization
+const pricingCountry = yieldable(batch(batch.groupBy(function *(calls) {
+  // Get pricing country for each organization and collect the results
+  const gres = yield tmap(calls, function *(call) {
+    const oid = calls[0][0];
+    const unlock = yield lock(oid);
+    try {
+      debug('Retrieving pricing country for org %s', oid);
 
-    // Look in our cache first
-    const cc = countries.get(oid);
-    if(cc)
-      return cc;
+      // Look in our cache first
+      const cc = countries.get(oid);
+      if(cc) return [undefined, cc];
 
-    // Forward authorization header field to account
-    const o = systemToken ? { headers: { authorization: systemToken() } } : {};
-    const account = yield brequest.get(
-      uris.account + '/v1/orgs/:org_id/account', extend(o, {
-        org_id: oid
-      }));
+      // Forward authorization header field to account
+      const o = systemToken ?
+        { headers: { authorization: systemToken() } } : {};
+      const account = yield brequest.get(
+        uris.account + '/v1/orgs/:org_id/account', extend(o, {
+          org_id: oid
+        }));
 
-    // Default to USA
-    const c = !account.body || !account.body.pricing_country ?
-      'USA' : account.body.pricing_country;
+      // Default to USA
+      const c = !account.body || !account.body.pricing_country ?
+        'USA' : account.body.pricing_country;
 
-    // Cache and return
-    countries.set(oid, c);
-    return c;
-  }
-  finally {
-    unlock();
-  }
-};
+      // Cache and return
+      countries.set(oid, c);
+      return [undefined, c];
+    }
+    finally {
+      unlock();
+    }
+  });
+
+  // Return the group results
+  return gres;
+}, function *(call) {
+  // group by organization - first argument
+  return call[0];
+})));
 
 // Return the configured price for the given plan, metric, and country
 const price = (pconf, pid, metric, country) => {
@@ -142,19 +154,24 @@ const rateUsage = function *(u, auth) {
   debug('Rating usage %o from %d', u, u.end);
 
   // Retrieve the pricing country configured for the org's account
-  const country = yield pricingCountry(u.organization_id, auth);
+  const country = yield pricingCountry(u.organization_id);
   debug('Pricing country %o', country);
 
+  // Retrieve all resources' metrics and price
+  const resourceConfigs = yield treduce(u.resources, function *(a, r) {
+    a[r.resource_id] = {
+      rconf: yield config(
+        r.resource_id, u.end, systemToken && systemToken()),
+      pconf: yield prices(
+        r.resource_id, u.end, systemToken && systemToken())
+    };
+    return a;
+  }, {});
+
   // Rate the aggregated usage under a resource
-  const rateResource = function *(rs) {
-
-    // Retrieve the metrics configured for the given resource
-    const rconf = yield config(
-      rs.resource_id, u.end, systemToken && systemToken());
-
-    // Retrieve the prices configured for the given resource
-    const pconf = yield prices(
-      rs.resource_id, u.end, systemToken && systemToken());
+  const rateResource = function(rs) {
+    const rconf = resourceConfigs[rs.resource_id].rconf;
+    const pconf = resourceConfigs[rs.resource_id].pconf;
 
     // Compute the cost of each metric under the resource plans
     return extend({}, rs, {
@@ -167,9 +184,9 @@ const rateUsage = function *(u, auth) {
           })
         });
       }),
-      plans: yield tmap(rs.plans, function *(p) {
+      plans: map(rs.plans, (p) => {
         return extend({}, p, {
-          aggregated_usage: yield tmap(p.aggregated_usage, function *(m) {
+          aggregated_usage: map(p.aggregated_usage, (m) => {
 
             // Find the rate function configured for each metric
             const rfn = ratefn(rconf.metrics, m.metric);
@@ -194,13 +211,13 @@ const rateUsage = function *(u, auth) {
 
   // Extend the aggregated usage with the computed costs
   const ru = extend({}, u, {
-    resources: yield tmap(u.resources, rateResource),
-    spaces: yield tmap(u.spaces, function *(space) {
+    resources: map(u.resources, rateResource),
+    spaces: map(u.spaces, (space) => {
       return extend({}, space, {
-        resources: yield tmap(space.resources, rateResource),
-        consumers: yield tmap(space.consumers, function *(consumer) {
+        resources: map(space.resources, rateResource),
+        consumers: map(space.consumers, (consumer) => {
           return extend({}, consumer, {
-            resources: yield tmap(consumer.resources, rateResource)
+            resources: map(consumer.resources, rateResource)
           });
         })
       });


### PR DESCRIPTION
Get pricing country using a grouped batch to avoid locking multiple times for
an organization.

Get configuration and pricing information for all resources in an organization
before calculating rating at all scopes.
