### PR TITLE
Improve usage aggregator performance

### DIFF
--- a/lib/aggregation/aggregator/src/index.js
+++ b/lib/aggregation/aggregator/src/index.js
@@ -20,7 +20,6 @@ const last = _.last;
 const extend = _.extend;
 const rest = _.rest;
 
-const tmap = yieldable(transform.map);
 const treduce = yieldable(transform.reduce);
 
 const config = yieldable(configcb);
@@ -232,14 +231,15 @@ const aggregate = function *(a, u, auth) {
       region: u.region
     });
 
+  // Get resource configuration
+  const conf = yield config(u.resource_id, u.end,
+    systemToken && systemToken());
+
   // Go through the incoming accumulated usage metrics
-  yield tmap(u.accumulated_usage, function *(ua) {
-
+  map(u.accumulated_usage, (ua) => {
     // Find the aggregate function for the given metric
-    const conf = yield config(u.resource_id, u.end,
-      systemToken && systemToken());
-
     const afn = aggrfn(conf.metrics, ua.metric);
+
     const aggr = (a, qty) => {
       // We're mutating the input quantity here but it's really the simplest
       // way to apply the aggregation formula

--- a/lib/aggregation/rate/src/index.js
+++ b/lib/aggregation/rate/src/index.js
@@ -30,7 +30,6 @@ const brequest = yieldable(retry(breaker(batch(request))));
 
 const lock = yieldable(lockcb);
 
-const tmap = yieldable(transform.map);
 const treduce = yieldable(transform.reduce);
 
 const config = yieldable(configcb);
@@ -88,40 +87,39 @@ const countries = lru({
 // Return the pricing country configured for an organization's account
 // using batch and group by organization
 const pricingCountry = yieldable(batch(batch.groupBy(function *(calls) {
-  // Get pricing country for each organization and collect the results
-  const gres = yield tmap(calls, function *(call) {
-    const oid = calls[0][0];
-    const unlock = yield lock(oid);
-    try {
-      debug('Retrieving pricing country for org %s', oid);
+  // Get pricing country for a given organization
+  const oid = calls[0][0];
+  debug('Retrieving pricing country for org %s', oid);
 
-      // Look in our cache first
-      const cc = countries.get(oid);
-      if(cc) return [undefined, cc];
+  // Look in our cache first
+  const cc = countries.get(oid);
+  if(cc) return map(calls, () => [undefined, cc]);
 
-      // Forward authorization header field to account
-      const o = systemToken ?
-        { headers: { authorization: systemToken() } } : {};
-      const account = yield brequest.get(
-        uris.account + '/v1/orgs/:org_id/account', extend(o, {
-          org_id: oid
-        }));
+  const unlock = yield lock(oid);
+  try {
+    // Look in our cache again
+    const cc = countries.get(oid);
+    if(cc) return map(calls, () => [undefined, cc]);
 
-      // Default to USA
-      const c = !account.body || !account.body.pricing_country ?
-        'USA' : account.body.pricing_country;
+    // Forward authorization header field to account
+    const o = systemToken ?
+      { headers: { authorization: systemToken() } } : {};
+    const account = yield brequest.get(
+      uris.account + '/v1/orgs/:org_id/account', extend(o, {
+        org_id: oid
+      }));
 
-      // Cache and return
-      countries.set(oid, c);
-      return [undefined, c];
-    }
-    finally {
-      unlock();
-    }
-  });
+    // Default to USA
+    const c = !account.body || !account.body.pricing_country ?
+      'USA' : account.body.pricing_country;
 
-  // Return the group results
-  return gres;
+    // Cache and return
+    countries.set(oid, c);
+    return map(calls, () => [undefined, c]);
+  }
+  finally {
+    unlock();
+  }
 }, function *(call) {
   // group by organization - first argument
   return call[0];


### PR DESCRIPTION
Avoid using asynchronous maps and get resource configuration before going
through each accumulated usage metrics.
