### PR TITLE
Enable Eureka application registration to work with latest version

### DIFF
--- a/lib/utils/eureka/src/index.js
+++ b/lib/utils/eureka/src/index.js
@@ -49,13 +49,21 @@ const register = (server, app, appindex, iindex, uri, port, cb) => {
       body: {
         instance: {
           dataCenterInfo: {
+            '@class': 'com.netflix.appinfo.InstanceInfo$DefaultDataCenterInfo',
             name: 'MyOwn'
           },
           app: app.toUpperCase(),
-          hostName: [[app, appindex].join('-'), iindex].join('.'),
+          asgName: app.toUpperCase(),
+          hostName: uri,
           ipAddr: uri,
           vipAddress: uri,
-          port: port,
+          port: {
+            $: port,
+            '@enabled': true
+          },
+          metadata: {
+            port: port
+          },
           status: 'UP'
         }
       }

--- a/lib/utils/eureka/src/test/test.js
+++ b/lib/utils/eureka/src/test/test.js
@@ -23,12 +23,21 @@ describe('abacus-eureka', () => {
         const instance = {
           instance: {
             app: 'TEST',
+            asgName: 'TEST',
             dataCenterInfo: {
+              '@class':
+                'com.netflix.appinfo.InstanceInfo$DefaultDataCenterInfo',
               name: 'MyOwn'
             },
-            hostName: 'test-0.0',
+            hostName: '127.0.0.1',
             ipAddr: '127.0.0.1',
-            port: 1234,
+            port: {
+              $: 1234,
+              '@enabled': true
+            },
+            metadata: {
+              port: 1234
+            },
             status: 'UP',
             vipAddress: '127.0.0.1'
           }


### PR DESCRIPTION
Update application instance registration details to be compatible with latest
Eureka. Added instance.dataCenterInfo.@class and converted instance.port
property to an object.

Add missing registration application instance properties needed for
Turbine 1.0.0 to work with latest Eureka. Added instance.asgName and
instance.metadata.port and Updated instance.hostName to have the URI
information.

Update the testcase to match with the registration payload change.

Related to #120.
